### PR TITLE
added tensorflow models for tabular regression

### DIFF
--- a/model_zoo/tabular_regression/tensorflow/CNN.py
+++ b/model_zoo/tabular_regression/tensorflow/CNN.py
@@ -1,0 +1,24 @@
+from tensorflow.keras import layers, models
+
+framework = "tensorflow"
+main_method = "MyModel"
+model_type = ""
+batch_size = 512
+output_classes = 1
+num_feature_points = 17
+category = "tabular_regression"
+
+
+def MyModel(input_size=num_feature_points, n_outputs=1):
+    model = models.Sequential(
+        [
+            layers.Input(shape=(input_size, 1)),
+            layers.Conv1D(16, 3, padding="same", activation="relu"),
+            layers.Conv1D(32, 3, padding="same", activation="relu"),
+            layers.Flatten(),
+            layers.Dense(128, activation="relu"),
+            layers.Dense(64, activation="relu"),
+            layers.Dense(n_outputs),
+        ]
+    )
+    return model

--- a/model_zoo/tabular_regression/tensorflow/FCN.py
+++ b/model_zoo/tabular_regression/tensorflow/FCN.py
@@ -1,0 +1,21 @@
+from tensorflow.keras import layers, models
+
+framework = "tensorflow"
+main_method = "MyModel"
+model_type = ""
+batch_size = 512
+output_classes = 1
+num_feature_points = 17
+category = "tabular_regression"
+
+
+def MyModel(input_shape=(num_feature_points,), n_outputs=1):
+    model = models.Sequential(
+        [
+            layers.Input(shape=input_shape),
+            layers.Dense(128, activation="relu"),
+            layers.Dense(64, activation="relu"),
+            layers.Dense(n_outputs),
+        ]
+    )
+    return model

--- a/model_zoo/tabular_regression/tensorflow/LSTM.py
+++ b/model_zoo/tabular_regression/tensorflow/LSTM.py
@@ -1,0 +1,18 @@
+from tensorflow.keras import layers, models
+
+framework = "tensorflow"
+main_method = "MyModel"
+model_type = ""
+batch_size = 512
+output_classes = 1
+num_feature_points = 17
+category = "tabular_regression"
+
+
+def MyModel(input_size=num_feature_points, hidden_size=128, n_outputs=1):
+    inputs = layers.Input(shape=(input_size,))
+    x = layers.Reshape((1, input_size))(inputs)
+    x = layers.LSTM(hidden_size)(x)
+    x = layers.Dense(64, activation="relu")(x)
+    outputs = layers.Dense(n_outputs)(x)
+    return models.Model(inputs, outputs)

--- a/model_zoo/tabular_regression/tensorflow/RNN.py
+++ b/model_zoo/tabular_regression/tensorflow/RNN.py
@@ -1,0 +1,18 @@
+from tensorflow.keras import layers, models
+
+framework = "tensorflow"
+main_method = "MyModel"
+model_type = ""
+batch_size = 512
+output_classes = 1
+num_feature_points = 17
+category = "tabular_regression"
+
+
+def MyModel(input_size=num_feature_points, hidden_size=128, n_outputs=1):
+    inputs = layers.Input(shape=(input_size,))
+    x = layers.Reshape((1, input_size))(inputs)
+    x = layers.SimpleRNN(hidden_size)(x)
+    x = layers.Dense(64, activation="relu")(x)
+    outputs = layers.Dense(n_outputs)(x)
+    return models.Model(inputs, outputs)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds new standalone model definitions without modifying existing training or inference logic. Main risk is shape/IO mismatch (e.g., `Conv1D` expects `(features, 1)`) if downstream loaders assume a different input format.
> 
> **Overview**
> Adds a new TensorFlow `tabular_regression` set of Keras models: `CNN`, `FCN`, `RNN`, and `LSTM`, each exposing a `MyModel` entrypoint and shared metadata (e.g., `batch_size`, `num_feature_points`, `output_classes`).
> 
> The architectures cover a simple dense network, a 1D-conv stack, and recurrent variants (`SimpleRNN`/`LSTM`) implemented via a reshape to a single-timestep sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95520a43b6aba08560221d3690bf4a77e1601b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->