### PR TITLE
fix: migrate deprecated pretrained=True to weights=DEFAULT

### DIFF
--- a/model_zoo/keypoint_detection/pytorch/CPN.py
+++ b/model_zoo/keypoint_detection/pytorch/CPN.py
@@ -35,7 +35,7 @@ class CascadedPyramidNetwork(nn.Module):
         super(CascadedPyramidNetwork, self).__init__()
 
         # Load a pretrained ResNet backbone
-        backbone = models.resnet50(pretrained=True)
+        backbone = models.resnet50(weights="DEFAULT")
 
         # Initial layers for feature extraction
         self.conv1 = backbone.conv1

--- a/model_zoo/keypoint_detection/pytorch/CPN_heatmap.py
+++ b/model_zoo/keypoint_detection/pytorch/CPN_heatmap.py
@@ -32,7 +32,7 @@ class CascadedPyramidNetwork(nn.Module):
         super(CascadedPyramidNetwork, self).__init__()
 
         # Load a pretrained ResNet backbone
-        backbone = models.resnet50(pretrained=True)
+        backbone = models.resnet50(weights="DEFAULT")
 
         # Initial layers for feature extraction
         self.conv1 = backbone.conv1

--- a/model_zoo/keypoint_detection/pytorch/FasterRCNNSPPE.py
+++ b/model_zoo/keypoint_detection/pytorch/FasterRCNNSPPE.py
@@ -19,7 +19,7 @@ class FasterRCNNSPPE(nn.Module):
         self.num_feature_points = num_feature_points
 
         # Load the Faster R-CNN model to get the backbone (ResNet-50)
-        model = fasterrcnn_resnet50_fpn(pretrained=True)
+        model = fasterrcnn_resnet50_fpn(weights="DEFAULT")
         backbone = model.backbone
 
         # Assume the feature extractor provides a feature map, which is what we use here

--- a/model_zoo/keypoint_detection/pytorch/ResNetSPPE.py
+++ b/model_zoo/keypoint_detection/pytorch/ResNetSPPE.py
@@ -19,7 +19,7 @@ class ResNetSPPE(nn.Module):
         self.num_feature_points = num_feature_points
 
         # Load a pre-trained ResNet model (here we use ResNet-50)
-        resnet = models.resnet50(pretrained=True)
+        resnet = models.resnet50(weights="DEFAULT")
 
         # Modify the first convolution layer to accommodate different input channels
         if input_channels != 3:

--- a/model_zoo/keypoint_detection/pytorch/resnet.py
+++ b/model_zoo/keypoint_detection/pytorch/resnet.py
@@ -18,7 +18,7 @@ class SimpleBaseline(nn.Module):
     def __init__(self, num_feature_points=num_feature_points):
         super(SimpleBaseline, self).__init__()
         # Load a pre-trained ResNet backbone
-        backbone = models.resnet50(pretrained=True)
+        backbone = models.resnet50(weights="DEFAULT")
         self.backbone = nn.Sequential(
             *(list(backbone.children())[:-2])
         )  # Remove the classification layers


### PR DESCRIPTION
## Summary

torchvision deprecated the `pretrained=` kwarg in 0.13 and removed it in 0.17. Any user on a modern torchvision would hit a `TypeError` loading these models.

This PR migrates the 5 remaining keypoint-detection files to the new `weights="DEFAULT"` API. The string form works across all torchvision weight-aware model builders and resolves to each architecture's `.DEFAULT` enum.

| File | Call migrated |
|---|---|
| `FasterRCNNSPPE.py` | `fasterrcnn_resnet50_fpn(weights="DEFAULT")` |
| `ResNetSPPE.py` | `models.resnet50(weights="DEFAULT")` |
| `CPN.py` | `models.resnet50(weights="DEFAULT")` |
| `CPN_heatmap.py` | `models.resnet50(weights="DEFAULT")` |
| `resnet.py` | `models.resnet50(weights="DEFAULT")` |

`alphapose.py` (the 6th affected file) was migrated in the earlier cleanup PR alongside its dead-code removal.

## Test plan

- [ ] On torchvision >= 0.17, each of these 5 files imports and instantiates without error.
- [ ] No `UserWarning` about deprecated `pretrained` kwarg when loading.
- [ ] `grep -r "pretrained=True" model_zoo/` returns no results.

Generated with [Claude Code](https://claude.com/claude-code)
