### PR TITLE
chore: add pre-commit config with narrow ruff rule set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Pre-commit hooks for model-zoo.
+#
+# Scope is deliberately narrow: the zoo is a collection of tutorial-style
+# model templates, not a codebase. Stylistic rules (line length, quote
+# style, etc.) would churn every file without improving template clarity.
+# These rules catch mistakes that actually bite users:
+#   F401 — unused imports (a real copy-paste bug we've hit)
+#   F821 — undefined names (catches broken symbol references)
+#   E9   — syntax errors
+#
+# To install locally: `pip install pre-commit && pre-commit install`
+# To run on all files: `pre-commit run --all-files`
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--select=F401,F821,E9", "--no-fix"]
+        files: ^model_zoo/.*\.py$


### PR DESCRIPTION
## Summary

Adds a minimal `.pre-commit-config.yaml` running [ruff](https://github.com/astral-sh/ruff) with a deliberately narrow rule set:

- **F401** — unused imports. The class of bug that shipped `import torch.nn as nn` in sklearn classifiers for who knows how long ([#30](https://github.com/tracebloc/model-zoo/pull/30)).
- **F821** — undefined names. Catches broken symbol references.
- **E9** — syntax errors. Catches file-level parse failures.

## Why not a full ruff/black/flake8 config

The zoo is a collection of tutorial-style templates. Users read these files to learn how to structure a model for the platform; aggressive auto-formatting (line length, quote style, import sorting) would churn every file without making them clearer. We keep the lint surface small and focused on correctness bugs that actually hurt users.

## Enabling locally

```bash
pip install pre-commit
pre-commit install
```

## Running on everything

```bash
pre-commit run --all-files
```

After [#30](https://github.com/tracebloc/model-zoo/pull/30) merges, this should be a no-op across the whole repo.

## Test plan

- [ ] `pre-commit run --all-files` passes on a clean checkout after [#30](https://github.com/tracebloc/model-zoo/pull/30) is in.
- [ ] Introducing an unused import in a model file causes pre-commit to fail.
- [ ] Files outside `model_zoo/` (README.md, etc.) are not touched by the hook.

Generated with [Claude Code](https://claude.com/claude-code)
