### PR TITLE
ci: add smoke test and GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install ruff
+      - run: ruff check --select=F401,F821,E9 model_zoo/
+
+  test-pytorch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install pytest torch torchvision transformers timm
+      - run: pytest tests/ -v
+
+  test-tensorflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install pytest tensorflow
+      - run: pytest tests/ -v
+
+  test-sklearn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install pytest scikit-learn xgboost lightgbm catboost
+      - run: pytest tests/ -v
+
+  test-survival:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - run: pip install pytest lifelines scikit-survival
+      - run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+          cache-dependency-path: .github/workflows/ci.yml
       - run: pip install ruff
       - run: ruff check --select=F401,F821,E9 model_zoo/
 
@@ -26,6 +27,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+          cache-dependency-path: .github/workflows/ci.yml
       - run: pip install pytest torch torchvision transformers timm
       - run: pytest tests/ -v
 
@@ -37,6 +39,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+          cache-dependency-path: .github/workflows/ci.yml
       - run: pip install pytest tensorflow
       - run: pytest tests/ -v
 
@@ -48,6 +51,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+          cache-dependency-path: .github/workflows/ci.yml
       - run: pip install pytest scikit-learn xgboost lightgbm catboost
       - run: pytest tests/ -v
 
@@ -59,5 +63,6 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+          cache-dependency-path: .github/workflows/ci.yml
       - run: pip install pytest lifelines scikit-survival
       - run: pytest tests/ -v

--- a/tests/test_model_contract.py
+++ b/tests/test_model_contract.py
@@ -1,0 +1,100 @@
+"""Smoke test: every model file imports and declares the expected metadata.
+
+Parametrized over every `.py` under `model_zoo/`. Files that do not declare
+a `framework = "..."` module attribute are treated as support files (e.g.
+loss.py, utils.py inside a packaged model folder) and skipped. Files whose
+framework is not installed in the current environment are also skipped —
+this lets the CI matrix run per-framework without re-installing everything.
+"""
+
+import importlib
+import importlib.util
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+MODEL_ROOT = ROOT / "model_zoo"
+
+FRAMEWORK_IMPORT_NAME = {
+    "pytorch": "torch",
+    "tensorflow": "tensorflow",
+    "sklearn": "sklearn",
+    "lifelines": "lifelines",
+    "scikit_survival": "sksurv",
+}
+KNOWN_FRAMEWORKS = set(FRAMEWORK_IMPORT_NAME)
+
+KNOWN_CATEGORIES = {
+    "image_classification",
+    "object_detection",
+    "text_classification",
+    "semantic_segmentation",
+    "keypoint_detection",
+    "tabular_classification",
+    "tabular_regression",
+    "time_series_forecasting",
+    "time_to_event_prediction",
+}
+
+
+def _read_framework(path: pathlib.Path) -> str | None:
+    """Extract `framework = "..."` without importing the file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    match = re.search(r'^\s*framework\s*=\s*["\'](\w+)["\']', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def _is_installed(framework: str) -> bool:
+    import_name = FRAMEWORK_IMPORT_NAME[framework]
+    try:
+        importlib.import_module(import_name)
+    except ImportError:
+        return False
+    return True
+
+
+def _model_files() -> list[pathlib.Path]:
+    return sorted(MODEL_ROOT.rglob("*.py"))
+
+
+@pytest.mark.parametrize("path", _model_files(), ids=lambda p: str(p.relative_to(ROOT)))
+def test_model_contract(path: pathlib.Path) -> None:
+    framework = _read_framework(path)
+    if framework is None:
+        pytest.skip("support file (no `framework` declaration)")
+
+    assert framework in KNOWN_FRAMEWORKS, (
+        f"{path}: declared framework {framework!r} is not in {KNOWN_FRAMEWORKS}"
+    )
+
+    if not _is_installed(framework):
+        pytest.skip(f"{framework} not installed in this CI job")
+
+    module_name = re.sub(r"\W", "_", path.stem)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader, f"{path}: importlib could not build a spec"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert getattr(module, "framework", None) == framework
+
+    category = getattr(module, "category", None)
+    assert category in KNOWN_CATEGORIES, (
+        f"{path}: declared category {category!r} is not in {KNOWN_CATEGORIES}"
+    )
+
+    parts = path.parts
+    mz_idx = parts.index("model_zoo")
+    task_from_path = parts[mz_idx + 1]
+    assert category == task_from_path, (
+        f"{path}: category {category!r} does not match task directory {task_from_path!r}"
+    )
+
+    entry = getattr(module, "main_class", None) or getattr(module, "main_method", None)
+    assert entry, f"{path}: neither main_class nor main_method is defined"
+    assert hasattr(module, entry), f"{path}: entry symbol {entry!r} not found in module"


### PR DESCRIPTION
## Summary

Gives the zoo its first CI. Two files:

- `tests/test_model_contract.py` — a parametrized pytest that iterates every `.py` under `model_zoo/` and verifies the module-level metadata contract. Files without a `framework = "..."` declaration (e.g. `loss.py` / `utils.py` inside packaged model folders) skip as support files. Files whose framework isn't installed in the current CI job also skip — this is what makes the parallel-job matrix work without re-installing every framework per job.

- `.github/workflows/ci.yml` — 5 parallel jobs on PRs to master and pushes to master.

## What the smoke test checks

Per file:

- `framework` is one of `{pytorch, tensorflow, sklearn, lifelines, scikit_survival}`
- `category` is declared, is a known task name, and matches the task directory the file lives under
- `main_class` or `main_method` resolves to a symbol actually defined in the module

This is the exact class of bug that shipped `import torch.nn as nn` in sklearn tabular classifiers for months (now fixed in [#30](https://github.com/tracebloc/model-zoo/pull/30)) and would have caught it on the PR that introduced it.

## CI job layout

| Job | Installs | Run |
|---|---|---|
| `ruff` | ruff | `ruff check --select=F401,F821,E9 model_zoo/` |
| `test-pytorch` | torch, torchvision, transformers, timm | full pytest |
| `test-tensorflow` | tensorflow | full pytest |
| `test-sklearn` | scikit-learn, xgboost, lightgbm, catboost | full pytest |
| `test-survival` | lifelines, scikit-survival | full pytest |

## Performance

With `actions/setup-python@v5` `cache: pip`:
- Warm cache: ~30–60s per job, ~2 min total wall clock (parallel).
- Cold cache (first run after a dep bump): ~2 min per job.

Acceptable for this repo's PR volume. Alternative prebuilt-Docker approach is documented in Lukas's plan but deferred until we see whether this is a bottleneck.

## Test plan

- [ ] This PR's own CI run passes on all 5 jobs.
- [ ] Introducing a model file with a wrong `category` causes `test-<framework>` to fail.
- [ ] Introducing a model file without `main_class` or `main_method` causes failure.
- [ ] Support files inside packaged folders (e.g. `yolo_v1/utils.py`) skip cleanly rather than fail.

Generated with [Claude Code](https://claude.com/claude-code)
