### PR TITLE
docs: add per-task README with "start here" picks and model tables

### DIFF
--- a/model_zoo/image_classification/README.md
+++ b/model_zoo/image_classification/README.md
@@ -1,0 +1,46 @@
+# Image classification
+
+Categorize images into predefined labels. All models accept `(B, 3, H, W)` RGB input and output `(B, num_classes)` logits.
+
+## Start here
+
+**New to image classification?** Use [`pytorch/resnet_18.py`](pytorch/resnet_18.py). Fast, well-understood, trains reliably on small datasets.
+
+## Models
+
+### PyTorch
+
+| Model | Params | When to pick |
+|---|---|---|
+| [`resnet_18.py`](pytorch/resnet_18.py) | ~11M | Fastest ResNet; baseline for quick iteration or CPU runs |
+| [`squeezenet.py`](pytorch/squeezenet.py) | ~1.2M | Extreme parameter efficiency; mobile/edge deployment |
+| [`vgg_16.py`](pytorch/vgg_16.py) | ~138M | Canonical heavy baseline via torchvision |
+| [`vgg_custom.py`](pytorch/vgg_custom.py) | — | Custom VGG implementation; pedagogical |
+| [`wide_resnet_50_2.py`](pytorch/wide_resnet_50_2.py) | ~69M | Wider than ResNet-50; often matches deeper nets |
+| [`maxvit.py`](pytorch/maxvit.py) | — | Hybrid CNN + transformer; strong accuracy, GPU-heavy |
+| [`swin_transformer.py`](pytorch/swin_transformer.py) | — | Shifted-window attention; GPU-friendly ViT alternative |
+| [`vit_b_16.py`](pytorch/vit_b_16.py) | ~86M | Standard Vision Transformer via torchvision |
+| [`vit.py`](pytorch/vit.py) | ~86M | ViT backbone + custom head (HuggingFace) |
+| [`vit_google.py`](pytorch/vit_google.py) | ~86M | Pretrained ViT classifier (HuggingFace) |
+| [`simple_cnn.py`](pytorch/simple_cnn.py) | — | Minimal CNN; pedagogical starting point |
+| [`lenet.py`](pytorch/lenet.py) | — | 1998 historical baseline; teaching only |
+
+### TensorFlow
+
+| Model | When to pick |
+|---|---|
+| [`resnet_50.py`](tensorflow/resnet_50.py) | Standard TF baseline |
+| [`densenet.py`](tensorflow/densenet.py) | Parameter-efficient dense connectivity |
+| [`efficientnet.py`](tensorflow/efficientnet.py) | Compound-scaled architecture |
+| [`vgg_16.py`](tensorflow/vgg_16.py) | Canonical heavy baseline |
+| [`xception.py`](tensorflow/xception.py) | Depthwise separable convs |
+| [`alexnet.py`](tensorflow/alexnet.py) | Historical baseline; teaching only |
+| [`lenet.py`](tensorflow/lenet.py) | Historical baseline; teaching only |
+| [`simple_cnn.py`](tensorflow/simple_cnn.py) | Minimal single-block CNN |
+| [`stacked_cnn.py`](tensorflow/stacked_cnn.py) | Multi-block CNN baseline |
+
+## Dataset expectations
+
+- **Input**: RGB images. `image_size = 224` by default; override per model.
+- **Labels**: integer class indices. `output_classes` configurable per file.
+- **Batch size**: default 256 (PyTorch), 128 (TensorFlow).

--- a/model_zoo/keypoint_detection/README.md
+++ b/model_zoo/keypoint_detection/README.md
@@ -1,0 +1,53 @@
+# Keypoint detection
+
+Detect landmarks on objects or bodies — e.g. human pose estimation (joint positions) or facial landmarks.
+
+Most models come in two flavors:
+- **direct regression** (predicts coordinates directly)
+- **heatmap-based** (predicts per-keypoint likelihood maps, usually more accurate)
+
+## Start here
+
+**New to keypoint detection?** Use [`pytorch/hrnet_heatmap.py`](pytorch/hrnet_heatmap.py). State-of-the-art accuracy on pose estimation benchmarks; well-understood architecture.
+
+For a lighter/faster baseline, use [`pytorch/resnet_sppe.py`](pytorch/resnet_sppe.py) (Single-Person Pose Estimator on a ResNet-50 backbone).
+
+## Models
+
+### Strong choices
+
+| Model | When to pick |
+|---|---|
+| [`hrnet_heatmap.py`](pytorch/hrnet_heatmap.py) | State-of-the-art pose accuracy |
+| [`hrnet.py`](pytorch/hrnet.py) | HRNet with direct regression |
+| [`alphapose.py`](pytorch/alphapose.py) | AlphaPose-style SimpleBaseline, configurable backbone |
+| [`resnet_sppe.py`](pytorch/resnet_sppe.py) | Lightweight SPPE on ResNet-50 |
+| [`faster_rcnn_sppe.py`](pytorch/faster_rcnn_sppe.py) | SPPE on Faster R-CNN backbone; reuses detection features |
+
+### Classical baselines
+
+| Model | Notes |
+|---|---|
+| [`cpn_heatmap.py`](pytorch/cpn_heatmap.py) | Cascaded Pyramid Network, heatmap output |
+| [`cpn.py`](pytorch/cpn.py) | Cascaded Pyramid Network, direct regression |
+| [`shg_heatmap.py`](pytorch/shg_heatmap.py) | Stacked Hourglass, heatmap output |
+| [`shg.py`](pytorch/shg.py) | Stacked Hourglass, direct regression |
+| [`cpm_heatmap.py`](pytorch/cpm_heatmap.py) | Convolutional Pose Machine, heatmap |
+| [`cpm.py`](pytorch/cpm.py) | Convolutional Pose Machine, direct |
+| [`openpose.py`](pytorch/openpose.py) | OpenPose-style multi-stage CNN |
+| [`dsnt.py`](pytorch/dsnt.py) | Differentiable Spatial-to-Numerical Transform |
+| [`deeppose.py`](pytorch/deeppose.py) | Historical: first deep pose estimator (2014) |
+
+### Other
+
+| Model | Notes |
+|---|---|
+| [`rcnn.py`](pytorch/rcnn.py) | R-CNN-style keypoint head |
+| [`resnet_50.py`](pytorch/resnet_50.py) | SimpleBaseline on ResNet-50 |
+| [`yolo_v8.py`](pytorch/yolo_v8.py) | YOLOv8 pose-estimation variant; single-pass detection + keypoints |
+
+## Dataset expectations
+
+- **Input**: RGB images (usually cropped around a detected person or object).
+- **Labels**: per-image keypoint coordinates + visibility, or per-keypoint heatmaps.
+- **`num_feature_points`**: typically 16–17 for human-body keypoints.

--- a/model_zoo/object_detection/README.md
+++ b/model_zoo/object_detection/README.md
@@ -1,0 +1,22 @@
+# Object detection
+
+Locate and classify multiple objects within an image. Models output bounding boxes + class predictions per detected object.
+
+## Start here
+
+**New to object detection?** Use [`pytorch/yolo_v8/`](pytorch/yolo_v8/). Fast, accurate, single-stage detector — the standard choice for most real-world use cases.
+
+## Models
+
+| Model | Type | When to pick |
+|---|---|---|
+| [`pytorch/yolo_v8/`](pytorch/yolo_v8/) | Single-stage | Fast, high accuracy, modern choice |
+| [`pytorch/yolo_v5/`](pytorch/yolo_v5/) | Single-stage | Slightly older YOLO; still widely deployed |
+| [`pytorch/yolo_v1/`](pytorch/yolo_v1/) | Single-stage | Canonical YOLO architecture; teaching/baseline |
+| [`pytorch/faster_rcnn_resnet.py`](pytorch/faster_rcnn_resnet.py) | Two-stage | Slower than YOLO, often more accurate on small objects |
+
+## Dataset expectations
+
+- **Input**: RGB images, variable resolution (YOLO auto-resizes to its input size).
+- **Labels**: per-image list of `(class_id, x, y, w, h)` bounding boxes (typically in normalized YOLO format).
+- **Multi-file YOLO models**: the folder's `model.py` is the entry point; `loss.py` / `utils.py` are internal.

--- a/model_zoo/semantic_segmentation/README.md
+++ b/model_zoo/semantic_segmentation/README.md
@@ -1,0 +1,24 @@
+# Semantic segmentation
+
+Pixel-level class labeling. Each output pixel gets a class assignment, so the result is a mask of the same spatial resolution as the input.
+
+## Start here
+
+**New to segmentation?** Use [`pytorch/unet.py`](pytorch/unet.py). Universal baseline — works on medical imaging, satellite data, and general-purpose segmentation with minimal tuning.
+
+## Models
+
+| Model | When to pick |
+|---|---|
+| [`unet.py`](pytorch/unet.py) | Universal baseline; default choice |
+| [`deeplab.py`](pytorch/deeplab.py) | Atrous convolutions for multi-scale context; strong on natural images |
+| [`fcn.py`](pytorch/fcn.py) | Canonical Fully Convolutional baseline |
+| [`hrnet.py`](pytorch/hrnet.py) | Maintains high-res features; strong on fine-detail tasks |
+| [`segnet.py`](pytorch/segnet.py) | Lightweight encoder-decoder; resource-constrained |
+| [`segmenter.py`](pytorch/segmenter.py) | Pure transformer; needs data and GPU time |
+
+## Dataset expectations
+
+- **Input**: RGB images, `(B, 3, H, W)`.
+- **Labels**: per-pixel class masks, `(B, H, W)` with integer class IDs.
+- **Batch size**: default 8 — segmentation masks are memory-heavy.

--- a/model_zoo/tabular_classification/README.md
+++ b/model_zoo/tabular_classification/README.md
@@ -1,0 +1,36 @@
+# Tabular classification
+
+Classify structured, tabular records into discrete categories.
+
+## Start here
+
+**New to tabular classification?** Use [`sklearn/xgboost.py`](sklearn/xgboost.py). On small and medium tabular datasets, gradient-boosted trees typically beat deep models — start here before trying PyTorch or TensorFlow variants.
+
+## Models
+
+### sklearn (usually the right choice for tabular)
+
+| Model | When to pick |
+|---|---|
+| [`xgboost.py`](sklearn/xgboost.py) | Strong default; usually wins on small/medium data |
+| [`lightgbm.py`](sklearn/lightgbm.py) | Faster training than XGBoost, often near-tied accuracy |
+| [`catboost.py`](sklearn/catboost.py) | Best handling of categorical features with minimal preprocessing |
+
+### PyTorch (pick when features have sequential/spatial structure)
+
+| Model | When to pick |
+|---|---|
+| [`fcn.py`](pytorch/fcn.py) | MLP baseline; default deep-learning choice |
+| [`cnn.py`](pytorch/cnn.py) | 1D CNN; use when feature order matters |
+| [`lstm.py`](pytorch/lstm.py) | LSTM; rows as sequences |
+| [`rnn.py`](pytorch/rnn.py) | Simple RNN; short sequences |
+
+### TensorFlow
+
+Same architectures as PyTorch, under [`tensorflow/`](tensorflow/). Pick the framework your team prefers.
+
+## Dataset expectations
+
+- **Input**: tabular rows with `num_feature_points` numeric features.
+- **Labels**: integer class IDs.
+- **Batch size**: default 4096 (PyTorch/TF), 512 (sklearn).

--- a/model_zoo/tabular_regression/README.md
+++ b/model_zoo/tabular_regression/README.md
@@ -1,0 +1,42 @@
+# Tabular regression
+
+Predict continuous target values from structured, tabular features.
+
+## Start here
+
+**New to tabular regression?** Use [`sklearn/xgboost.py`](sklearn/xgboost.py). Gradient-boosted trees typically dominate on tabular data — start here before trying deep models.
+
+For a fast, zero-tuning baseline, use [`sklearn/random_forest.py`](sklearn/random_forest.py) or [`sklearn/linear_regression.py`](sklearn/linear_regression.py).
+
+## Models
+
+### sklearn (usually the right choice for tabular)
+
+| Model | When to pick |
+|---|---|
+| [`xgboost.py`](sklearn/xgboost.py) | Strongest default |
+| [`lightgbm.py`](sklearn/lightgbm.py) | Fast training; near-XGBoost accuracy |
+| [`random_forest.py`](sklearn/random_forest.py) | Robust out-of-the-box baseline |
+| [`gradient_boosting.py`](sklearn/gradient_boosting.py) | Classical sklearn boosting |
+| [`decision_tree.py`](sklearn/decision_tree.py) | Interpretable single tree; high variance |
+| [`knn.py`](sklearn/knn.py) | Small datasets with meaningful distance |
+| [`mlp.py`](sklearn/mlp.py) | Small feed-forward net inside sklearn |
+| [`svm.py`](sklearn/svm.py) | Moderate data with kernel methods |
+| [`linear_regression.py`](sklearn/linear_regression.py) | Always run this first as a floor |
+| [`ridge.py`](sklearn/ridge.py) | L2 regularization; correlated features |
+| [`lasso.py`](sklearn/lasso.py) | L1 regularization; feature selection |
+| [`elastic_net.py`](sklearn/elastic_net.py) | L1 + L2; sparsity with stability |
+
+### PyTorch
+
+| Model | When to pick |
+|---|---|
+| [`fcn.py`](pytorch/fcn.py) | MLP baseline |
+| [`cnn.py`](pytorch/cnn.py) | 1D CNN; ordered features |
+| [`rnn.py`](pytorch/rnn.py) | Short-sequence RNN |
+
+## Dataset expectations
+
+- **Input**: tabular rows with `num_feature_points` numeric features.
+- **Labels**: continuous target values.
+- **Batch size**: default 4096 (PyTorch), 512 (sklearn).

--- a/model_zoo/text_classification/README.md
+++ b/model_zoo/text_classification/README.md
@@ -1,0 +1,26 @@
+# Text classification
+
+Classify documents, reviews, tickets, or any short-to-medium-length text into predefined labels.
+
+## Start here
+
+**New to text classification?** Use [`pytorch/distilbert.py`](pytorch/distilbert.py). ~60% the size of BERT-base, ~97% of its accuracy — the strongest default when inference speed or model size matters.
+
+If you want absolute maximum accuracy and can afford the compute, use [`pytorch/roberta_base.py`](pytorch/roberta_base.py).
+
+## Models
+
+| Model | Params | When to pick |
+|---|---|---|
+| [`distilbert.py`](pytorch/distilbert.py) | ~66M | Fast, pretrained; default for most tasks |
+| [`bert_base_uncased.py`](pytorch/bert_base_uncased.py) | ~110M | Canonical BERT baseline; pretrained |
+| [`roberta_base.py`](pytorch/roberta_base.py) | ~125M | Often beats BERT on downstream tasks |
+| [`distilbert_scratch.py`](pytorch/distilbert_scratch.py) | ~66M | DistilBERT without pretrained weights; rarely the right choice |
+| [`bert_base_uncased_scratch.py`](pytorch/bert_base_uncased_scratch.py) | ~110M | BERT from scratch; only for massive domain-specific corpora |
+| [`simple_text.py`](pytorch/simple_text.py) | — | Embedding + dense layers; quick prototyping on small corpora |
+
+## Dataset expectations
+
+- **Input**: text strings; tokenization happens inside the model via HuggingFace tokenizers.
+- **Labels**: integer class indices.
+- **Batch size**: default 512.

--- a/model_zoo/time_series_forecasting/README.md
+++ b/model_zoo/time_series_forecasting/README.md
@@ -1,0 +1,26 @@
+# Time series forecasting
+
+Predict future values of a sequence from its past values. All models expect sequential input and output a `forecast_horizon` of future predictions.
+
+## Start here
+
+**New to time-series forecasting?** Use [`pytorch/lstm.py`](pytorch/lstm.py). Solid general-purpose sequence model — start here before reaching for transformers.
+
+For long-horizon forecasting, try [`pytorch/tcn.py`](pytorch/tcn.py) (Temporal Convolutional Network) — dilated causal convolutions often beat RNNs on long sequences.
+
+## Models
+
+| Model | When to pick |
+|---|---|
+| [`lstm.py`](pytorch/lstm.py) | Default sequence model; reliable baseline |
+| [`bidirectional_lstm.py`](pytorch/bidirectional_lstm.py) | Reads each sequence both directions; future context during training |
+| [`gru.py`](pytorch/gru.py) | Lighter than LSTM; faster training on short sequences |
+| [`rnn.py`](pytorch/rnn.py) | Vanilla RNN; weak for long sequences |
+| [`tcn.py`](pytorch/tcn.py) | Dilated causal convs; strong for long-horizon forecasting |
+| [`transformer.py`](pytorch/transformer.py) | Self-attention; needs a lot of data to justify |
+
+## Dataset expectations
+
+- **Input**: `(B, sequence_length, num_features)`.
+- **Output**: `(B, forecast_horizon, num_features)` (or similar, per model).
+- **`sequence_length`**, **`forecast_horizon`**: declared per model file, override for your use case.

--- a/model_zoo/time_to_event_prediction/README.md
+++ b/model_zoo/time_to_event_prediction/README.md
@@ -1,0 +1,44 @@
+# Time-to-event prediction (survival analysis)
+
+Predict when an event will occur, given features and possibly censored observations (subjects who haven't experienced the event yet).
+
+This directory is unusual in that it offers three different libraries:
+- **`lifelines/`** — classical parametric survival models. Interpretable, fast, well-understood.
+- **`scikit_survival/`** — Cox proportional hazards with sklearn-style API.
+- **`pytorch/`** — neural survival models for non-linear hazard modeling.
+
+## Start here
+
+**New to survival analysis?** Use [`lifelines/weibull_aft.py`](lifelines/weibull_aft.py). Most common parametric survival baseline; trains instantly and gives interpretable coefficients.
+
+For deep-learning approaches, try [`pytorch/deepsurv.py`](pytorch/deepsurv.py) — neural Cox proportional hazards model.
+
+## Models
+
+### lifelines (classical parametric)
+
+| Model | When to pick |
+|---|---|
+| [`weibull_aft.py`](lifelines/weibull_aft.py) | Most common parametric baseline |
+| [`log_normal_aft.py`](lifelines/log_normal_aft.py) | When `log(time)` is approximately normal |
+| [`log_logistic_aft.py`](lifelines/log_logistic_aft.py) | Non-monotonic hazards |
+
+### scikit_survival
+
+| Model | When to pick |
+|---|---|
+| [`cox_ph.py`](scikit_survival/cox_ph.py) | Classical semi-parametric Cox model; interpretable coefficients |
+
+### PyTorch (neural survival)
+
+| Model | When to pick |
+|---|---|
+| [`deepsurv.py`](pytorch/deepsurv.py) | Neural Cox; non-linear hazards |
+| [`multilayer_norm.py`](pytorch/multilayer_norm.py) | Deep model with normalization; moderate-size datasets |
+| [`simple_neural.py`](pytorch/simple_neural.py) | Small feed-forward net; starting point for deep survival |
+| [`simple_linear.py`](pytorch/simple_linear.py) | Linear survival model; comparison against lifelines |
+
+## Dataset expectations
+
+- **Input**: tabular rows with `num_feature_points` numeric features.
+- **Labels**: `(time_to_event, event_observed)` pairs. `event_observed=0` means censored.


### PR DESCRIPTION
## Summary

Adds a `README.md` to every task directory under `model_zoo/`. Each one gives the task a one-line definition, recommends a "start here" model, and lists every model in the directory as a scannable table with "when to pick" notes.

## Why

The `start-training` notebook hardcodes an image-classification default (`densenet.py`). When a user's task isn't image classification, they currently have to grep 92 files to find a suitable replacement. These READMEs give them a landing page per task — one click from the zoo root, one decision to make.

## "Start here" recommendations

| Task | Recommended | Reason |
|---|---|---|
| Image classification | `pytorch/resnet_18.py` | Fast, well-understood, trains reliably on small data |
| Object detection | `pytorch/yolo_v8/` | Standard modern choice; fast + accurate |
| Text classification | `pytorch/distilbert.py` | ~60% BERT's size, ~97% accuracy |
| Semantic segmentation | `pytorch/unet.py` | Universal baseline across domains |
| Keypoint detection | `pytorch/hrnet_heatmap.py` | State-of-the-art pose accuracy |
| Tabular classification | `sklearn/xgboost.py` | Gradient boosting usually beats deep on tabular |
| Tabular regression | `sklearn/xgboost.py` | Same reason |
| Time-series forecasting | `pytorch/lstm.py` | Solid general-purpose sequence model |
| Time-to-event | `lifelines/weibull_aft.py` | Most common parametric survival baseline |

These are opinions. If the tracebloc team has stronger internal preferences (e.g. a specific model you've validated works best on typical customer data), swap them.

## Filenames used in links

Links use the **post-rename** filenames (per [#33](https://github.com/tracebloc/model-zoo/pull/33), [#34](https://github.com/tracebloc/model-zoo/pull/34), [#35](https://github.com/tracebloc/model-zoo/pull/35), [#36](https://github.com/tracebloc/model-zoo/pull/36), [#37](https://github.com/tracebloc/model-zoo/pull/37)). Until those merge, the links will 404. After they merge, the links all resolve.

**Recommended merge order**: merge the rename PRs first, then merge this PR. If this PR merges first, follow up with a quick rebase that updates any links that didn't survive.

## Test plan

- [ ] Render each README on GitHub after all rename PRs land; all internal links resolve.
- [ ] Spot-check 2–3 READMEs on mobile (GitHub table rendering at narrow widths).
- [ ] Confirm each "start here" recommendation matches what the tracebloc team would actually recommend.

Generated with [Claude Code](https://claude.com/claude-code)
