### PR TITLE
docs: clarify pretrained-weights convention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Full walkthrough → [Open the training notebook in Colab](https://colab.researc
 
 Not limited to this zoo. Any model that follows the [model structure requirements](https://docs.tracebloc.io/join-use-case/model-optimization) works — PyTorch, TensorFlow, or custom containers.
 
-**Weight file convention:** if your model is `mymodel.py`, name the weights `mymodel_weights.pkl` and place them in the same directory.
+## Pretrained weights
+
+Models in this zoo do not ship pretrained weights. Each model loads weights through its underlying library at runtime — torchvision's `weights="DEFAULT"`, HuggingFace's `from_pretrained()`, or training from scratch.
+
+If you're uploading **your own** model and want to bundle pretrained weights with it, name the weights file `mymodel_weights.pkl` and place it in the same directory as `mymodel.py`. The platform will pick it up automatically.
 
 ## Links
 


### PR DESCRIPTION
Closes #47

## Summary

- Removes the misleading "Weight file convention" line that implied the zoo ships pretrained weights
- Adds a new "Pretrained weights" section that clarifies: weights load at runtime via each library

## Test plan

- [x] Existing weight-file convention preserved (still applies for user-uploaded models)
- [ ] README renders correctly on github.com (verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)