### PR TITLE
ci: add kanban closure-routing caller workflow

### DIFF
--- a/.github/workflows/kanban-closure-routing.yml
+++ b/.github/workflows/kanban-closure-routing.yml
@@ -1,0 +1,12 @@
+name: Kanban closure routing
+
+on:
+  pull_request:
+    types: [closed]
+  issues:
+    types: [closed]
+
+jobs:
+  route:
+    uses: tracebloc/.github/.github/workflows/kanban-closure-router.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a 9-line caller workflow that triggers the org-wide reusable workflow [`tracebloc/.github/.github/workflows/kanban-closure-router.yml`](https://github.com/tracebloc/.github/blob/main/.github/workflows/kanban-closure-router.yml) on PR/issue close events.

## What it does

| Event | Status set |
|---|---|
| PR merged | Done |
| PR closed without merge | Cancelled |
| Issue closed as completed | Done |
| Issue closed as not_planned (or no reason) | Cancelled |

Replaces the imprecise built-in "Item closed" workflow which sets every closed item to the same Status.

## Activation

After this caller merges, all closure events in this repo route correctly to the kanban. Same pattern as the existing `advance-deploy-env`, `set-pr-status`, and `customer-priority-bump` callers.

Implements [tracebloc/.github#14](https://github.com/tracebloc/.github/issues/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)