### PR TITLE
fix: drop stray torch import from sklearn classifiers

### DIFF
--- a/model_zoo/tabular_classification/sklearn/catboost.py
+++ b/model_zoo/tabular_classification/sklearn/catboost.py
@@ -1,5 +1,4 @@
 """CatBoost classifier, 100 trees. Strong on categorical features with minimal preprocessing."""
-import torch.nn as nn
 from catboost import CatBoostClassifier
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/decisiontree.py
+++ b/model_zoo/tabular_classification/sklearn/decisiontree.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.tree import DecisionTreeClassifier
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/gbm.py
+++ b/model_zoo/tabular_classification/sklearn/gbm.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.ensemble import GradientBoostingClassifier
 
 

--- a/model_zoo/tabular_classification/sklearn/k-neighbor.py
+++ b/model_zoo/tabular_classification/sklearn/k-neighbor.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.neighbors import KNeighborsClassifier
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/lightgbm.py
+++ b/model_zoo/tabular_classification/sklearn/lightgbm.py
@@ -1,5 +1,4 @@
 """LightGBM classifier, 100 trees. Fast gradient boosting; often near-tied with XGBoost."""
-import torch.nn as nn
 from lightgbm import LGBMClassifier
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/logistic_regression.py
+++ b/model_zoo/tabular_classification/sklearn/logistic_regression.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.linear_model import LogisticRegression
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/mlp.py
+++ b/model_zoo/tabular_classification/sklearn/mlp.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.neural_network import MLPClassifier
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/naivebyes.py
+++ b/model_zoo/tabular_classification/sklearn/naivebyes.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.naive_bayes import GaussianNB
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/randomforest.py
+++ b/model_zoo/tabular_classification/sklearn/randomforest.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.ensemble import RandomForestClassifier
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/svm.py
+++ b/model_zoo/tabular_classification/sklearn/svm.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from sklearn.svm import SVC
 
 framework = "sklearn"

--- a/model_zoo/tabular_classification/sklearn/xgboost.py
+++ b/model_zoo/tabular_classification/sklearn/xgboost.py
@@ -1,5 +1,4 @@
 """XGBoost classifier, 100 trees. Strong tabular baseline; usually beats deep models on small/medium datasets."""
-import torch.nn as nn
 from xgboost import XGBClassifier
 
 framework = "sklearn"


### PR DESCRIPTION
## Summary
- 11 files under `model_zoo/tabular_classification/sklearn/` declare `framework = "sklearn"` but had `import torch.nn as nn` at the top, with `nn` never used anywhere in the file.
- The stray import broke the `test-sklearn` and `test-survival` CI jobs on [#42](https://github.com/tracebloc/model-zoo/pull/42) — neither job installs torch, so every one of these files raised `ModuleNotFoundError: No module named 'torch'` during the contract test's `importlib.exec_module` call.
- Targeting `develop` so #42 picks the fix up automatically.

## Test plan
- [ ] CI `test-sklearn` job goes green on this PR
- [ ] CI `test-survival` job no longer reports the torch import errors (separate `xgboost`/`lightgbm` install gap on the survival job is out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only deletes an unused import across several small model stub modules; behavior is unchanged except imports no longer require `torch`.
> 
> **Overview**
> Removes the unused `import torch.nn as nn` line from 11 `model_zoo/tabular_classification/sklearn/*` model definition modules so they no longer require `torch` just to import.
> 
> This prevents `ModuleNotFoundError` failures in environments/CI jobs that only install sklearn-related dependencies (e.g., contract tests that import these modules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47bfa33e0745b2f3596c9998364cde43e2024af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->