### PR TITLE
fix: pin revision on every from_pretrained() call

### DIFF
--- a/model_zoo/image_classification/pytorch/vit.py
+++ b/model_zoo/image_classification/pytorch/vit.py
@@ -10,8 +10,7 @@ batch_size = 16
 category = "image_classification"
 output_classes = 2
 
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. See
+# model version
 # https://huggingface.co/google/vit-base-patch16-224/commits/main
 VIT_REVISION = "3f49326eb077187dfe1c2a2bb15fbd74e6ab91e3"
 

--- a/model_zoo/image_classification/pytorch/vit.py
+++ b/model_zoo/image_classification/pytorch/vit.py
@@ -10,13 +10,20 @@ batch_size = 16
 category = "image_classification"
 output_classes = 2
 
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. See
+# https://huggingface.co/google/vit-base-patch16-224/commits/main
+VIT_REVISION = "3f49326eb077187dfe1c2a2bb15fbd74e6ab91e3"
+
 
 class VisionTransformer(nn.Module):
     def __init__(self):
         super().__init__()
         # Initialize the configuration for ViT
         self.config = ViTConfig.from_pretrained(
-            "google/vit-base-patch16-224", num_labels=output_classes
+            "google/vit-base-patch16-224",
+            revision=VIT_REVISION,
+            num_labels=output_classes,
         )
 
         # Initialize the ViT model

--- a/model_zoo/image_classification/pytorch/vit_google.py
+++ b/model_zoo/image_classification/pytorch/vit_google.py
@@ -11,16 +11,26 @@ batch_size = 16
 category = "image_classification"
 output_classes = 2
 
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. See
+# https://huggingface.co/google/vit-base-patch16-224/commits/main
+VIT_REVISION = "3f49326eb077187dfe1c2a2bb15fbd74e6ab91e3"
+
 
 class VisionTransformer(nn.Module):
     def __init__(self):
         super().__init__()
         # Initialize the model with a specified number of output labels for classification
         config = ViTConfig.from_pretrained(
-            "google/vit-base-patch16-224", num_labels=output_classes
+            "google/vit-base-patch16-224",
+            revision=VIT_REVISION,
+            num_labels=output_classes,
         )
         self.vit = ViTForImageClassification.from_pretrained(
-            "google/vit-base-patch16-224", config=config, ignore_mismatched_sizes=True
+            "google/vit-base-patch16-224",
+            revision=VIT_REVISION,
+            config=config,
+            ignore_mismatched_sizes=True,
         )
 
     def forward(self, pixel_values):

--- a/model_zoo/image_classification/pytorch/vit_google.py
+++ b/model_zoo/image_classification/pytorch/vit_google.py
@@ -11,8 +11,7 @@ batch_size = 16
 category = "image_classification"
 output_classes = 2
 
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. See
+# model version
 # https://huggingface.co/google/vit-base-patch16-224/commits/main
 VIT_REVISION = "3f49326eb077187dfe1c2a2bb15fbd74e6ab91e3"
 

--- a/model_zoo/semantic_segmentation/pytorch/segmenter.py
+++ b/model_zoo/semantic_segmentation/pytorch/segmenter.py
@@ -12,14 +12,20 @@ batch_size = 8
 output_classes = 2
 category = "semantic_segmentation"
 
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. See
+# https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512/commits/main
+SEGFORMER_REVISION = "489d5cd81a0b59fab9b7ea758d3548ebe99677da"
+
 
 class Segmenter(nn.Module):
     def __init__(self, model_name="nvidia/segformer-b0-finetuned-ade-512-512"):
         super(Segmenter, self).__init__()
-        
+
         # Load Segformer model from Hugging Face
         self.model = SegformerForSemanticSegmentation.from_pretrained(
             model_name,
+            revision=SEGFORMER_REVISION,
             num_labels=output_classes,
             ignore_mismatched_sizes=True
         )

--- a/model_zoo/semantic_segmentation/pytorch/segmenter.py
+++ b/model_zoo/semantic_segmentation/pytorch/segmenter.py
@@ -12,20 +12,23 @@ batch_size = 8
 output_classes = 2
 category = "semantic_segmentation"
 
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. See
+# model version
 # https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512/commits/main
 SEGFORMER_REVISION = "489d5cd81a0b59fab9b7ea758d3548ebe99677da"
 
 
 class Segmenter(nn.Module):
-    def __init__(self, model_name="nvidia/segformer-b0-finetuned-ade-512-512"):
+    def __init__(
+        self,
+        model_name="nvidia/segformer-b0-finetuned-ade-512-512",
+        revision=SEGFORMER_REVISION,
+    ):
         super(Segmenter, self).__init__()
 
         # Load Segformer model from Hugging Face
         self.model = SegformerForSemanticSegmentation.from_pretrained(
             model_name,
-            revision=SEGFORMER_REVISION,
+            revision=revision,
             num_labels=output_classes,
             ignore_mismatched_sizes=True
         )

--- a/model_zoo/text_classification/pytorch/bert_base_uncased.py
+++ b/model_zoo/text_classification/pytorch/bert_base_uncased.py
@@ -3,6 +3,10 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = 'bert-base-uncased'
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. See
+# https://huggingface.co/bert-base-uncased/commits/main
+model_revision = "86b5e0934494bd15c9632b12f734a8a67f723594"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -13,6 +17,9 @@ output_classes = 5
 
 def MyModel(num_classes=output_classes):
 
-    return AutoModelForSequenceClassification.from_pretrained(model_id,
+    return AutoModelForSequenceClassification.from_pretrained(
+        model_id,
+        revision=model_revision,
         num_labels=num_classes,
-        ignore_mismatched_sizes=True)
+        ignore_mismatched_sizes=True,
+    )

--- a/model_zoo/text_classification/pytorch/bert_base_uncased.py
+++ b/model_zoo/text_classification/pytorch/bert_base_uncased.py
@@ -3,10 +3,6 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = 'bert-base-uncased'
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. See
-# https://huggingface.co/bert-base-uncased/commits/main
-model_revision = "86b5e0934494bd15c9632b12f734a8a67f723594"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -14,6 +10,10 @@ model_type = ""
 batch_size = 512
 sequence_length = 5
 output_classes = 5
+
+# model version
+# https://huggingface.co/bert-base-uncased/commits/main
+model_revision = "86b5e0934494bd15c9632b12f734a8a67f723594"
 
 def MyModel(num_classes=output_classes):
 

--- a/model_zoo/text_classification/pytorch/bert_base_uncased_scratch.py
+++ b/model_zoo/text_classification/pytorch/bert_base_uncased_scratch.py
@@ -3,6 +3,10 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "bert-base-uncased"
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. See
+# https://huggingface.co/bert-base-uncased/commits/main
+model_revision = "86b5e0934494bd15c9632b12f734a8a67f723594"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -13,5 +17,7 @@ output_classes = 5
 
 
 def MyModel(num_classes=output_classes):
-    config = AutoConfig.from_pretrained(model_id, num_labels=num_classes)
+    config = AutoConfig.from_pretrained(
+        model_id, revision=model_revision, num_labels=num_classes
+    )
     return AutoModelForSequenceClassification.from_config(config)

--- a/model_zoo/text_classification/pytorch/bert_base_uncased_scratch.py
+++ b/model_zoo/text_classification/pytorch/bert_base_uncased_scratch.py
@@ -3,10 +3,6 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "bert-base-uncased"
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. See
-# https://huggingface.co/bert-base-uncased/commits/main
-model_revision = "86b5e0934494bd15c9632b12f734a8a67f723594"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -14,6 +10,10 @@ model_type = ""
 batch_size = 512
 sequence_length = 5
 output_classes = 5
+
+# model version
+# https://huggingface.co/bert-base-uncased/commits/main
+model_revision = "86b5e0934494bd15c9632b12f734a8a67f723594"
 
 
 def MyModel(num_classes=output_classes):

--- a/model_zoo/text_classification/pytorch/distilbert.py
+++ b/model_zoo/text_classification/pytorch/distilbert.py
@@ -3,11 +3,6 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. Update this when you
-# want to consume a newer upstream version — see
-# https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english/commits/main
-model_revision = "714eb0fa89d2f80546fda750413ed43d93601a13"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -15,6 +10,10 @@ model_type = ""
 batch_size = 512
 sequence_length = 5
 output_classes = 5
+
+# model version
+# https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english/commits/main
+model_revision = "714eb0fa89d2f80546fda750413ed43d93601a13"
 
 
 def MyModel(num_classes=output_classes):

--- a/model_zoo/text_classification/pytorch/distilbert.py
+++ b/model_zoo/text_classification/pytorch/distilbert.py
@@ -3,6 +3,11 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. Update this when you
+# want to consume a newer upstream version — see
+# https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english/commits/main
+model_revision = "714eb0fa89d2f80546fda750413ed43d93601a13"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -15,5 +20,8 @@ output_classes = 5
 def MyModel(num_classes=output_classes):
 
     return AutoModelForSequenceClassification.from_pretrained(
-        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+        model_id,
+        revision=model_revision,
+        num_labels=num_classes,
+        ignore_mismatched_sizes=True,
     )

--- a/model_zoo/text_classification/pytorch/distilbert_scratch.py
+++ b/model_zoo/text_classification/pytorch/distilbert_scratch.py
@@ -3,10 +3,6 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. See
-# https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english/commits/main
-model_revision = "714eb0fa89d2f80546fda750413ed43d93601a13"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -14,6 +10,10 @@ model_type = ""
 batch_size = 512
 sequence_length = 5
 output_classes = 5
+
+# model version
+# https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english/commits/main
+model_revision = "714eb0fa89d2f80546fda750413ed43d93601a13"
 
 
 def MyModel(num_classes=output_classes):

--- a/model_zoo/text_classification/pytorch/distilbert_scratch.py
+++ b/model_zoo/text_classification/pytorch/distilbert_scratch.py
@@ -3,6 +3,10 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. See
+# https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english/commits/main
+model_revision = "714eb0fa89d2f80546fda750413ed43d93601a13"
 framework = "pytorch"
 main_class = "MyModel"
 category = "text_classification"
@@ -13,5 +17,7 @@ output_classes = 5
 
 
 def MyModel(num_classes=output_classes):
-    config = AutoConfig.from_pretrained(model_id, num_labels=num_classes)
+    config = AutoConfig.from_pretrained(
+        model_id, revision=model_revision, num_labels=num_classes
+    )
     return AutoModelForSequenceClassification.from_config(config)

--- a/model_zoo/text_classification/pytorch/roberta_base.py
+++ b/model_zoo/text_classification/pytorch/roberta_base.py
@@ -3,6 +3,10 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "roberta-base"
+# Pin a specific commit on HF Hub: the backend security check rejects
+# from_pretrained() calls without revision pinning. See
+# https://huggingface.co/roberta-base/commits/main
+model_revision = "e2da8e2f811d1448a5b465c236feacd80ffbac7b"
 tokenizer_id = "roberta-base"
 hf_token = ""
 framework = "pytorch"
@@ -17,6 +21,7 @@ output_classes = 5
 def MyModel(num_classes=output_classes):
     config = AutoConfig.from_pretrained(
         model_id,
+        revision=model_revision,
         token=hf_token,
         num_labels=num_classes,
         problem_type="single_label_classification",
@@ -25,5 +30,9 @@ def MyModel(num_classes=output_classes):
         classifier_dropout=0.3,
     )
     return AutoModelForSequenceClassification.from_pretrained(
-        model_id, token=hf_token, config=config, ignore_mismatched_sizes=True
+        model_id,
+        revision=model_revision,
+        token=hf_token,
+        config=config,
+        ignore_mismatched_sizes=True,
     )

--- a/model_zoo/text_classification/pytorch/roberta_base.py
+++ b/model_zoo/text_classification/pytorch/roberta_base.py
@@ -3,10 +3,6 @@ from transformers import AutoModelForSequenceClassification
 from transformers import AutoConfig
 
 model_id = "roberta-base"
-# Pin a specific commit on HF Hub: the backend security check rejects
-# from_pretrained() calls without revision pinning. See
-# https://huggingface.co/roberta-base/commits/main
-model_revision = "e2da8e2f811d1448a5b465c236feacd80ffbac7b"
 tokenizer_id = "roberta-base"
 hf_token = ""
 framework = "pytorch"
@@ -16,6 +12,10 @@ model_type = ""
 batch_size = 512
 sequence_length = 128
 output_classes = 5
+
+# model version
+# https://huggingface.co/roberta-base/commits/main
+model_revision = "e2da8e2f811d1448a5b465c236feacd80ffbac7b"
 
 
 def MyModel(num_classes=output_classes):


### PR DESCRIPTION
Pin a `revision="<commit-sha>"` on every `from_pretrained()` call across the 8 affected model-zoo files.

## Why

The tracebloc backend's security check (Bandit + custom plugin) rejects uploaded model files that contain `from_pretrained()` calls without a `revision=` argument:

```
ModelValidationError: 'distilbert' upload failed: server did not return a model id.
Reason: server validation rejected the model: Model is insecure.
Errors: Unsafe Hugging Face Hub download without revision pinning in from_pretrained()
```

The check is correct on its merits — without revision pinning, `from_pretrained` returns whatever's at HF Hub HEAD of the named repo, which can change under you and is a real supply-chain concern. Every model-zoo file that hits HF Hub needs the same fix or it'll fail upload validation the same way.

## Changes

SHAs were fetched from each repo's `main` branch via the HF Hub API at time of writing:
```bash
curl -sL "https://huggingface.co/api/models/<repo>/refs"
```

| File | HF repo | Pinned SHA |
|---|---|---|
| `distilbert.py` | `distilbert/distilbert-base-uncased-finetuned-sst-2-english` | `714eb0fa` |
| `distilbert_scratch.py` | `distilbert/distilbert-base-uncased-finetuned-sst-2-english` | `714eb0fa` |
| `bert_base_uncased.py` | `bert-base-uncased` | `86b5e093` |
| `bert_base_uncased_scratch.py` | `bert-base-uncased` | `86b5e093` |
| `roberta_base.py` | `roberta-base` | `e2da8e2f` |
| `segmenter.py` | `nvidia/segformer-b0-finetuned-ade-512-512` | `489d5cd8` |
| `vit.py` | `google/vit-base-patch16-224` | `3f49326e` |
| `vit_google.py` | `google/vit-base-patch16-224` | `3f49326e` |

Total: 8 files, 8 unique HF repos collapsed to 5, 10 `from_pretrained()` call sites updated.

## Convention

Each file declares `model_revision = "<sha>"` near the existing `model_id` and passes it as `revision=model_revision` to `from_pretrained()`. Files where the model id appears only as a constructor default (no module-level `model_id`) use a `<NAME>_REVISION` module-level constant instead — see `segmenter.py`, `vit.py`, `vit_google.py`.

Each block has a comment pointing at the upstream commits page so a future maintainer who wants a newer version knows exactly where to look.

## How to bump revisions in the future

When you want to consume a newer upstream version of any pinned model, run:
```bash
curl -sL "https://huggingface.co/api/models/<repo>/refs" | python3 -m json.tool
```
Copy the `targetCommit` of `main` (or whichever branch) into the `model_revision` constant.

Or via the HF web UI: `https://huggingface.co/<repo>/commits/main` → click any commit → copy the SHA from the URL.

## Test plan

- [x] Every `from_pretrained()` call site in `model_zoo/` now has a `revision=` kwarg (verified with `grep -rn "from_pretrained" model_zoo/`)
- [ ] `python -c "import <each file>"` smoke import — manual; reviewer to run
- [ ] End-to-end: `user.upload_model("<file>")` against the backend should now pass the security check (was failing before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change that only pins specific Hugging Face Hub commit SHAs for model/config downloads; main behavioral impact is making weights/config deterministic (and potentially different from whatever Hub HEAD would return at runtime).
> 
> **Overview**
> Pins Hugging Face Hub downloads to specific commit SHAs across the model zoo by adding per-model revision constants and passing `revision=...` to all affected `from_pretrained()` calls.
> 
> This makes model/config resolution deterministic and addresses security/validation failures caused by unpinned Hub HEAD downloads (including `ViT`, `SegFormer`, `BERT`, `DistilBERT`, and `RoBERTa` variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd7a4aec1161ccf5433299d2e1e31df650d5061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->