### PR TITLE
fix: replace dynamic getattr in alphapose to pass TBT001 validator

### DIFF
--- a/model_zoo/keypoint_detection/pytorch/alphapose.py
+++ b/model_zoo/keypoint_detection/pytorch/alphapose.py
@@ -259,8 +259,17 @@ class MyModel(nn.Module):
 
         # Imagenet pretrain model
         import torchvision.models as tm   # noqa: F401,F403
-        # assert cfg['NUM_LAYERS'] in [18, 34, 50, 101, 152]
-        x = getattr(tm, f"resnet{cfg['NUM_LAYERS']}")(weights="DEFAULT")
+        resnet_factories = {
+            18: tm.resnet18,
+            34: tm.resnet34,
+            50: tm.resnet50,
+            101: tm.resnet101,
+            152: tm.resnet152,
+        }
+        num_layers = cfg['NUM_LAYERS']
+        if num_layers not in resnet_factories:
+            raise ValueError(f"Unsupported NUM_LAYERS: {num_layers}")
+        x = resnet_factories[num_layers](weights="DEFAULT")
 
         model_state = self.preact.state_dict()
         state = {k: v for k, v in x.state_dict().items()


### PR DESCRIPTION
## Summary

Replace dynamic `getattr(tm, f"resnet{cfg['NUM_LAYERS']}")` in `alphapose.py` with a static dispatch dict so the model passes the tightened backend validator.

## Type of change

- [x] Bug fix

## Root cause

Single line at `model_zoo/keypoint_detection/pytorch/alphapose.py:263`:

```python
x = getattr(tm, f"resnet{cfg['NUM_LAYERS']}")(weights="DEFAULT")
```

The second argument is an f-string, not a string literal. Backend [tracebloc/backend#640](https://github.com/tracebloc/backend/pull/640) added TBT001: *"Reject `getattr`/`setattr` calls whose second argument is not a string `ast.Constant`."* Idiomatic `getattr(obj, "fc")` still passes; dynamic name does not.

Validator output observed:

```
ModelValidationError: 'alphapose' upload failed: server validation rejected the model:
Model is insecure. Errors: Use of getattr with a dynamic name argument is forbidden;
name must be a string literal
```

A repo-wide scan confirmed no other model-zoo file hits this rule — only alphapose.

## Fix

Replace the dynamic `getattr` with an explicit `{depth: factory}` mapping. Each `tm.resnetXX` is a static attribute access, so the validator sees nothing dynamic. Preserves the configurable `NUM_LAYERS` behavior the module docstring promises, and turns the commented-out `assert cfg['NUM_LAYERS'] in [18, 34, 50, 101, 152]` into a real `ValueError` on unsupported depths.

## Note on line 258

`ResNet(f"resnet{cfg['NUM_LAYERS']}")` is fine to leave: it's a string passed into `ResNet.__init__`, which does its own dict lookup (lines 175–181 in the same file). No `getattr` involved.

## Out of scope

`NUM_LAYERS` is hardcoded to 50 in the shipped `config` dict and no code path overrides `cfg`, so the configurability is largely theoretical — we could simplify by hardcoding `tm.resnet50(...)`. Deliberately deferred to a separate PR to keep this one focused on the validator fix.

## Test plan

- [ ] Re-upload `alphapose` against backend running PR #640's plugin; confirm no `'getattr with a dynamic name'` finding.
- [ ] Confirm the model still constructs and trains end-to-end (the constructor on line 263 runs at `MyModel.__init__`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes how the pretrained torchvision ResNet constructor is selected and adds explicit validation for unsupported `NUM_LAYERS` values.
> 
> **Overview**
> Replaces the dynamic `getattr(tm, f"resnet{NUM_LAYERS}")` call in `alphapose.py` with an explicit `{depth: torchvision factory}` dispatch map to satisfy stricter model validation.
> 
> Adds a `ValueError` when `cfg['NUM_LAYERS']` is not one of the supported ResNet depths (18/34/50/101/152), otherwise preserving the existing pretrained-weight loading behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457486b8647089ae02389a583d0a909abb9e8978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->