### PR TITLE
refactor: remove unused `import torch` from model files

### DIFF
--- a/model_zoo/image_classification/pytorch/lenet.py
+++ b/model_zoo/image_classification/pytorch/lenet.py
@@ -1,5 +1,4 @@
 """LeNet-5 (LeCun, 1998). Historical baseline; tiny and trains fast. Pick only for very small datasets or teaching."""
-import torch
 import torch.nn as nn
 
 framework = "pytorch"

--- a/model_zoo/image_classification/pytorch/maxvit.py
+++ b/model_zoo/image_classification/pytorch/maxvit.py
@@ -1,5 +1,4 @@
 """MaxViT via torchvision. Hybrid CNN + transformer. Strong accuracy but memory-hungry; needs a good GPU."""
-import torch
 import torchvision
 import torch.nn as nn
 

--- a/model_zoo/image_classification/pytorch/resnet_18.py
+++ b/model_zoo/image_classification/pytorch/resnet_18.py
@@ -1,5 +1,4 @@
 """ResNet-18 via torchvision, ~11M params. Fastest ResNet; good baseline for quick iteration or CPU-constrained runs."""
-import torch
 import torchvision
 import torch.nn as nn
 

--- a/model_zoo/image_classification/pytorch/squeezenet.py
+++ b/model_zoo/image_classification/pytorch/squeezenet.py
@@ -1,5 +1,4 @@
 """SqueezeNet via torchvision, ~1.2M params. Extreme parameter efficiency; pick for mobile or edge deployment."""
-import torch
 import torchvision
 import torch.nn as nn
 

--- a/model_zoo/image_classification/pytorch/swin_transformer.py
+++ b/model_zoo/image_classification/pytorch/swin_transformer.py
@@ -1,5 +1,4 @@
 """Swin Transformer via torchvision. Shifted-window attention; high accuracy and more GPU-friendly than pure ViT at similar capacity."""
-import torch
 import torchvision
 import torch.nn as nn
 

--- a/model_zoo/image_classification/pytorch/vgg_16.py
+++ b/model_zoo/image_classification/pytorch/vgg_16.py
@@ -1,5 +1,4 @@
 """VGG-16 via torchvision, ~138M params. Canonical baseline; heavy for modern standards but still a solid comparison point."""
-import torch
 import torchvision
 import torch.nn as nn
 

--- a/model_zoo/image_classification/pytorch/vgg_custom.py
+++ b/model_zoo/image_classification/pytorch/vgg_custom.py
@@ -1,5 +1,4 @@
 """Custom 109-line VGG implementation. Pick only if you need VGG built from scratch; prefer vggnet_16.py (torchvision wrapper) for training."""
-import torch
 import torch.nn as nn
 
 framework = "pytorch"

--- a/model_zoo/image_classification/pytorch/vit.py
+++ b/model_zoo/image_classification/pytorch/vit.py
@@ -1,5 +1,4 @@
 """ViT-B/16 backbone from HuggingFace transformers + custom classification head. Pick when you want to swap the head or extract features."""
-import torch
 from torch import nn
 from transformers import ViTModel, ViTConfig
 

--- a/model_zoo/image_classification/pytorch/vit_b_16.py
+++ b/model_zoo/image_classification/pytorch/vit_b_16.py
@@ -1,5 +1,4 @@
 """ViT-B/16 via torchvision, ~86M params. Standard Vision Transformer; needs a large dataset or strong pretraining."""
-import torch
 import torchvision
 import torch.nn as nn
 

--- a/model_zoo/image_classification/pytorch/vit_google.py
+++ b/model_zoo/image_classification/pytorch/vit_google.py
@@ -1,5 +1,4 @@
 """ViT-B/16 via HuggingFace ViTForImageClassification, google/vit-base-patch16-224 weights. Pretrained classifier; fine-tune the head for your classes."""
-import torch
 from torch import nn
 from transformers import ViTForImageClassification, ViTConfig
 

--- a/model_zoo/image_classification/pytorch/wide_resnet_50_2.py
+++ b/model_zoo/image_classification/pytorch/wide_resnet_50_2.py
@@ -1,5 +1,4 @@
 """Wide ResNet-50-2 via torchvision, ~69M params. Wider than ResNet-50; often matches or beats deeper ResNets."""
-import torch
 import torchvision
 import torch.nn as nn
 

--- a/model_zoo/keypoint_detection/pytorch/faster_rcnn_sppe.py
+++ b/model_zoo/keypoint_detection/pytorch/faster_rcnn_sppe.py
@@ -1,5 +1,4 @@
 """Single-Person Pose Estimator on a Faster R-CNN ResNet-50 backbone. Reuses a strong detection backbone for keypoints."""
-import torch
 import torch.nn as nn
 from torchvision.models.detection import fasterrcnn_resnet50_fpn
 

--- a/model_zoo/keypoint_detection/pytorch/resnet_sppe.py
+++ b/model_zoo/keypoint_detection/pytorch/resnet_sppe.py
@@ -1,5 +1,4 @@
 """Single-Person Pose Estimator on a ResNet-50 backbone. Simpler than FasterRCNNSPPE; good default when you don't need detection."""
-import torch
 import torch.nn as nn
 import torchvision.models as models
 

--- a/model_zoo/keypoint_detection/pytorch/shg.py
+++ b/model_zoo/keypoint_detection/pytorch/shg.py
@@ -1,5 +1,4 @@
 """Stacked Hourglass Network (direct regression). Symmetric encoder-decoder stack; classic pose architecture."""
-import torch
 import torch.nn as nn
 
 # Configuration

--- a/model_zoo/keypoint_detection/pytorch/shg_heatmap.py
+++ b/model_zoo/keypoint_detection/pytorch/shg_heatmap.py
@@ -1,5 +1,4 @@
 """Stacked Hourglass Network with heatmap output. Usually the better SHG variant."""
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/model_zoo/object_detection/pytorch/faster_rcnn_resnet.py
+++ b/model_zoo/object_detection/pytorch/faster_rcnn_resnet.py
@@ -1,5 +1,4 @@
 """Faster R-CNN with a ResNet backbone. Two-stage detector; strong accuracy, slower than YOLO variants."""
-import torch
 import torch.nn as nn
 import torchvision
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor

--- a/model_zoo/object_detection/pytorch/yolo_v1/model.py
+++ b/model_zoo/object_detection/pytorch/yolo_v1/model.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 

--- a/model_zoo/object_detection/pytorch/yolo_v5/model.py
+++ b/model_zoo/object_detection/pytorch/yolo_v5/model.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 framework = "pytorch"
@@ -10,7 +9,6 @@ output_classes = 3
 category = "object_detection"
 
 
-import torch
 import torch.nn as nn
 
 class ConvBNAct(nn.Module):

--- a/model_zoo/semantic_segmentation/pytorch/deeplab.py
+++ b/model_zoo/semantic_segmentation/pytorch/deeplab.py
@@ -1,5 +1,4 @@
 """DeepLab semantic segmentation. Atrous convolutions for multi-scale context; strong accuracy on natural images."""
-import torch
 import torch.nn as nn
 from torchvision.models.segmentation import deeplabv3_resnet50, deeplabv3_resnet101
 

--- a/model_zoo/semantic_segmentation/pytorch/fcn.py
+++ b/model_zoo/semantic_segmentation/pytorch/fcn.py
@@ -1,5 +1,4 @@
 """Fully Convolutional Network for segmentation. Canonical baseline; simple and well-understood."""
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/model_zoo/semantic_segmentation/pytorch/segmenter.py
+++ b/model_zoo/semantic_segmentation/pytorch/segmenter.py
@@ -1,5 +1,4 @@
 """Segmenter: pure-transformer segmentation model. Pick when you have a lot of data and GPU time."""
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers import SegformerForSemanticSegmentation, SegformerConfig

--- a/model_zoo/semantic_segmentation/pytorch/segnet.py
+++ b/model_zoo/semantic_segmentation/pytorch/segnet.py
@@ -1,5 +1,4 @@
 """SegNet encoder-decoder. Lightweight; good for resource-constrained settings."""
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/model_zoo/time_to_event_prediction/pytorch/deepsurv.py
+++ b/model_zoo/time_to_event_prediction/pytorch/deepsurv.py
@@ -1,5 +1,4 @@
 """DeepSurv: neural Cox proportional hazards model. Pick when you need non-linear hazard modeling."""
-import torch
 import torch.nn as nn
 
 framework = "pytorch"

--- a/model_zoo/time_to_event_prediction/pytorch/multilayer_norm.py
+++ b/model_zoo/time_to_event_prediction/pytorch/multilayer_norm.py
@@ -1,5 +1,4 @@
 """Multilayer normalized survival net. Deep model with normalization; good default for moderately sized datasets."""
-import torch
 import torch.nn as nn
 
 framework = "pytorch"

--- a/model_zoo/time_to_event_prediction/pytorch/simple_linear.py
+++ b/model_zoo/time_to_event_prediction/pytorch/simple_linear.py
@@ -1,5 +1,4 @@
 """Linear survival model in PyTorch. Simplest deep-learning baseline; use to compare against lifelines."""
-import torch
 import torch.nn as nn
 
 framework = "pytorch"

--- a/model_zoo/time_to_event_prediction/pytorch/simple_neural.py
+++ b/model_zoo/time_to_event_prediction/pytorch/simple_neural.py
@@ -1,5 +1,4 @@
 """Small feed-forward survival net. One hidden layer; good starting point for deep survival modeling."""
-import torch
 import torch.nn as nn
 
 framework = "pytorch"


### PR DESCRIPTION
## Summary

- Bare `import torch` was unused in 26 PyTorch model files across `image_classification/`, `keypoint_detection/`, `object_detection/`, `semantic_segmentation/`, and `time_to_event_prediction/`.
- Only submodule imports like `import torch.nn as nn` or `from torch import ...` are actually referenced — those remain untouched.
- Verified by grepping `\btorch\b` outside import lines: zero matches in any of the 26 files.

## Test plan

- [ ] `python -c "import ast; [ast.parse(open(f).read()) for f in <changed files>]"` to confirm files still parse.
- [ ] Upload one of the changed models via `user.uploadModel(...)` to confirm the SDK still loads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only removes unused top-level `import torch` statements; runtime behavior should be unchanged aside from slightly faster imports/cleaner linting.
> 
> **Overview**
> Removes unused bare `import torch` statements across multiple PyTorch model definitions in the model zoo (image classification, detection, segmentation, keypoint, and survival models), keeping the actually-used submodule imports (e.g., `torch.nn`, `torchvision`, `transformers`).
> 
> This is a cleanup-only change intended to reduce lint/noise and avoid misleading dependencies without altering model architectures or configuration constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6110423691d6eeabed26b9d987f4e04fd063bf41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->