### PR TITLE
refactor: remove unused `import tensorflow as tf` from model files

### DIFF
--- a/model_zoo/image_classification/tensorflow/lenet.py
+++ b/model_zoo/image_classification/tensorflow/lenet.py
@@ -1,5 +1,4 @@
 """LeNet-5 via TensorFlow Sequential API. Historical baseline for small images; trains fast."""
-import tensorflow as tf
 from tensorflow.keras import layers, models
 
 framework = "tensorflow"

--- a/model_zoo/image_classification/tensorflow/simple_cnn.py
+++ b/model_zoo/image_classification/tensorflow/simple_cnn.py
@@ -1,5 +1,4 @@
 """Minimal single-block CNN via TensorFlow Sequential API. Pedagogical starting point for building your own model."""
-import tensorflow as tf
 from tensorflow.keras import layers, models
 
 framework = "tensorflow"

--- a/model_zoo/image_classification/tensorflow/stacked_cnn.py
+++ b/model_zoo/image_classification/tensorflow/stacked_cnn.py
@@ -1,5 +1,4 @@
 """Stacked-block CNN via TensorFlow Sequential API. Simple baseline with moderate depth."""
-import tensorflow as tf
 from tensorflow.keras import layers, models
 
 framework = "tensorflow"


### PR DESCRIPTION
## Summary

- `lenet.py`, `simple_cnn.py`, `stacked_cnn.py` under `image_classification/tensorflow/` imported `tensorflow as tf` but never referenced `tf` — only `from tensorflow.keras import ...` is actually used.
- Other tensorflow models (`densenet`, `resnet_50`, `vgg_16`, `xception`, `alexnet`) do use `tf.keras.Model` / `tf.keras.Input` and are untouched.

## Test plan

- [ ] Confirm the three files still parse and load via `user.uploadModel(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes unused `import tensorflow as tf` statements without changing model definitions or runtime behavior.
> 
> **Overview**
> Removes unused `import tensorflow as tf` from the TensorFlow Sequential model files `lenet.py`, `simple_cnn.py`, and `stacked_cnn.py`, leaving only the `tensorflow.keras` imports. No functional changes to model construction or exported metadata/constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c23253d9f9b44f72952b1d7f43e385ef8ab29f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->