### PR TITLE
refactor: remove unused imports flagged by ruff

### DIFF
--- a/model_zoo/image_classification/tensorflow/alexnet.py
+++ b/model_zoo/image_classification/tensorflow/alexnet.py
@@ -1,6 +1,6 @@
 """AlexNet (2012) via TensorFlow Sequential API. Historical baseline; pick for teaching or comparison, not modern accuracy."""
 import tensorflow as tf
-from tensorflow.keras import layers, utils
+from tensorflow.keras import layers
 
 framework = "tensorflow"
 main_method = "MyModel"

--- a/model_zoo/image_classification/tensorflow/densenet.py
+++ b/model_zoo/image_classification/tensorflow/densenet.py
@@ -1,6 +1,6 @@
 """DenseNet (TensorFlow Functional API, custom). Dense connectivity between layers; parameter-efficient for a given accuracy."""
 import tensorflow as tf
-from tensorflow.keras import layers, utils
+from tensorflow.keras import layers
 
 # Dense Block
 framework = "tensorflow"

--- a/model_zoo/image_classification/tensorflow/efficientnet.py
+++ b/model_zoo/image_classification/tensorflow/efficientnet.py
@@ -1,7 +1,6 @@
 """EfficientNet (TensorFlow Functional API, custom). Compound-scaled architecture balancing depth, width, and resolution."""
 from tensorflow import keras
 from tensorflow.keras import layers
-from tensorflow.keras.utils import plot_model
 import math
 
 framework = "tensorflow"

--- a/model_zoo/image_classification/tensorflow/resnet_50.py
+++ b/model_zoo/image_classification/tensorflow/resnet_50.py
@@ -1,7 +1,6 @@
 """ResNet-50 (TensorFlow Functional API, custom). Canonical accuracy/compute trade-off; standard baseline."""
 import tensorflow as tf
 from tensorflow.keras import layers
-from tensorflow.keras.utils import plot_model
 
 framework = "tensorflow"
 main_method = "MyModel"

--- a/model_zoo/image_classification/tensorflow/vgg_16.py
+++ b/model_zoo/image_classification/tensorflow/vgg_16.py
@@ -1,6 +1,6 @@
 """VGG-16 (TensorFlow Functional API, custom). Heavy but canonical baseline."""
 import tensorflow as tf
-from tensorflow.keras import layers, utils
+from tensorflow.keras import layers
 
 framework = "tensorflow"
 main_method = "MyModel"

--- a/model_zoo/image_classification/tensorflow/xception.py
+++ b/model_zoo/image_classification/tensorflow/xception.py
@@ -1,6 +1,6 @@
 """Xception (TensorFlow Functional API, custom). Depthwise separable convolutions throughout; Inception's successor."""
 import tensorflow as tf
-from tensorflow.keras import layers, utils
+from tensorflow.keras import layers
 
 framework = "tensorflow"
 main_method = "MyModel"

--- a/model_zoo/object_detection/pytorch/faster_rcnn_resnet.py
+++ b/model_zoo/object_detection/pytorch/faster_rcnn_resnet.py
@@ -1,6 +1,4 @@
 """Faster R-CNN with a ResNet backbone. Two-stage detector; strong accuracy, slower than YOLO variants."""
-import torch
-import torch.nn as nn
 import torchvision
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 from torchvision.models.detection import FasterRCNN_ResNet50_FPN_Weights

--- a/model_zoo/object_detection/pytorch/yolo_v8/model.py
+++ b/model_zoo/object_detection/pytorch/yolo_v8/model.py
@@ -1,8 +1,6 @@
 import torch
 import torch.nn as nn
 import math
-import torchvision
-from torch.nn.functional import cross_entropy, one_hot
 
 framework = "pytorch"
 model_type = "yolo"

--- a/model_zoo/semantic_segmentation/pytorch/segmenter.py
+++ b/model_zoo/semantic_segmentation/pytorch/segmenter.py
@@ -1,8 +1,6 @@
 """Segmenter: pure-transformer segmentation model. Pick when you have a lot of data and GPU time."""
-import torch
 import torch.nn as nn
-import torch.nn.functional as F
-from transformers import SegformerForSemanticSegmentation, SegformerConfig
+from transformers import SegformerForSemanticSegmentation
 
 # Configuration
 framework = "pytorch"

--- a/model_zoo/text_classification/pytorch/bert_base_uncased.py
+++ b/model_zoo/text_classification/pytorch/bert_base_uncased.py
@@ -1,6 +1,5 @@
 """BERT-base-uncased via HuggingFace, pretrained. Standard text classification baseline; fine-tune the head for your labels."""
 from transformers import AutoModelForSequenceClassification
-from transformers import AutoConfig
 
 model_id = 'bert-base-uncased'
 framework = "pytorch"

--- a/model_zoo/text_classification/pytorch/distilbert.py
+++ b/model_zoo/text_classification/pytorch/distilbert.py
@@ -1,6 +1,5 @@
 """DistilBERT via HuggingFace, pretrained. ~60% the size of BERT-base, ~97% of its accuracy; strong default for inference-speed-sensitive setups."""
 from transformers import AutoModelForSequenceClassification
-from transformers import AutoConfig
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
 framework = "pytorch"


### PR DESCRIPTION
## Summary

Cleans up F401 unused-import warnings reported by ruff across 11 model files:

- **tensorflow keras**: dropped unused `utils` / `plot_model` from `alexnet.py`, `densenet.py`, `efficientnet.py`, `resnet_50.py`, `vgg_16.py`, `xception.py`
- **object_detection**: dropped unused `torch.nn`, `torchvision`, `cross_entropy`, `one_hot` from `faster_rcnn_resnet.py` and `yolo_v8/model.py`
- **semantic_segmentation/segmenter**: dropped unused `torch.nn.functional as F` and `SegformerConfig`
- **text_classification**: dropped unused `transformers.AutoConfig` from `bert_base_uncased.py` and `distilbert.py`

## Test plan

- [ ] Re-run ruff to confirm zero remaining F401 in the listed files.
- [ ] Spot-load one model from each affected directory via the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup limited to removing unused imports; runtime behavior should be unchanged aside from potential import-time errors if those symbols were implicitly relied on (unlikely).
> 
> **Overview**
> Removes ruff `F401` unused-import violations across the model zoo by dropping unused `keras.utils`/`plot_model` imports in several TensorFlow image classification models, unused Torch/TorchVision/functionals in object detection models, unused `SegformerConfig`/`torch.nn.functional` in `segmenter.py`, and unused `AutoConfig` in the BERT/DistilBERT text classifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e0ec17414d9f05e70f660643f0acf3f4dd1b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->