### PR TITLE
test: skip model contract tests when optional deps are missing

### DIFF
--- a/tests/test_model_contract.py
+++ b/tests/test_model_contract.py
@@ -26,6 +26,8 @@ FRAMEWORK_IMPORT_NAME = {
 }
 KNOWN_FRAMEWORKS = set(FRAMEWORK_IMPORT_NAME)
 
+OPTIONAL_THIRD_PARTY = {"xgboost", "lightgbm", "catboost"}
+
 KNOWN_CATEGORIES = {
     "image_classification",
     "object_detection",
@@ -58,6 +60,21 @@ def _is_installed(framework: str) -> bool:
     return True
 
 
+def _missing_optional_deps(path: pathlib.Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    found = set(re.findall(r"^\s*(?:from|import)\s+(\w+)", text, re.MULTILINE))
+    missing = []
+    for mod in sorted(found & OPTIONAL_THIRD_PARTY):
+        try:
+            importlib.import_module(mod)
+        except ImportError:
+            missing.append(mod)
+    return missing
+
+
 def _model_files() -> list[pathlib.Path]:
     return sorted(MODEL_ROOT.rglob("*.py"))
 
@@ -74,6 +91,10 @@ def test_model_contract(path: pathlib.Path) -> None:
 
     if not _is_installed(framework):
         pytest.skip(f"{framework} not installed in this CI job")
+
+    missing = _missing_optional_deps(path)
+    if missing:
+        pytest.skip(f"optional dep(s) not installed in this CI job: {', '.join(missing)}")
 
     module_name = re.sub(r"\W", "_", path.stem)
     spec = importlib.util.spec_from_file_location(module_name, path)


### PR DESCRIPTION
## Summary
- `test-survival` was failing on the 5 sklearn-tagged tabular models that import xgboost/lightgbm/catboost. `scikit-survival` pulls in `scikit-learn` transitively, so the framework gate (`_is_installed("sklearn")`) passed and the test then tried to exec the module and hit `ModuleNotFoundError`.
- Added an optional-dep probe: regex-scan the file's top-level `import`/`from` lines for known optional third-party packages (`xgboost`, `lightgbm`, `catboost`) and skip the test when any aren't importable.
- `test-sklearn` still installs all three, so real coverage is unchanged; only the other jobs now skip cleanly.

## Test plan
- [x] Local run with sklearn present but xgboost/lightgbm/catboost absent → those 5 tests skip instead of fail (99 passed, 15 skipped).
- [x] CI: `test-survival` goes green; `test-sklearn` still executes the 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that adds additional skip conditions; main impact is slightly reduced coverage in CI jobs that don’t install optional ML libraries.
> 
> **Overview**
> Updates `tests/test_model_contract.py` to detect imports of optional third-party packages (`xgboost`, `lightgbm`, `catboost`) and **skip** the model contract smoke test when those dependencies aren’t available.
> 
> This prevents CI jobs that only install a framework’s core deps from failing on model files that require these optional libraries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f3c7e3fe8b5fe1e32dd2a124b239010e1e025d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->