### PR TITLE
Add 10 trending model architectures across all task families

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,15 @@ Every model file defines:
 - `main_class` OR `main_method`: the symbol the SDK loads (class for `nn.Module` subclasses, function for factory-style models)
 - `category`: must match the task directory name
 - `batch_size`, `output_classes`, plus task-specific fields (`image_size`, `num_feature_points`, `sequence_length`, `forecast_horizon`, etc.)
+- `license` (recommended for new files): SPDX-style string such as `"Apache-2.0"`, `"MIT"`, `"AGPL-3.0"`, or `"non-commercial"`. Lets downstream tooling filter models by license — important since some pretrained weights ship under restrictive terms.
+
+## Federated averaging conventions
+
+The averaging service averages model parameters per-tensor across clients. New pretrained models should be authored with this in mind:
+
+- **BatchNorm running stats** (`running_mean` / `running_var`) average poorly across non-IID clients. Either freeze BN layers (`eval()` + `requires_grad=False`) or replace with `GroupNorm` / `LayerNorm`.
+- **EMA buffers** (some detectors, Mamba SSMs) are not trained parameters — strip them or document the workaround.
+- **Foundation models** (Mitra, Chronos, ModernBERT-large, etc.) should be fine-tuned **LoRA-only** via `peft`. Freeze the base model and only the small adapter tensors get averaged. This is the only tractable path for >100M-param backbones over federated clients.
 
 ## File naming convention
 

--- a/model_zoo/image_classification/pytorch/convnext_v2.py
+++ b/model_zoo/image_classification/pytorch/convnext_v2.py
@@ -1,0 +1,22 @@
+"""ConvNeXt V2 via timm. Modern CNN default — FCMAE-pretrained, ~88.9% ImageNet top-1 at Huge scale; Tiny variant here is the practical sweet spot."""
+import timm
+import torch.nn as nn
+
+framework = "pytorch"
+main_class = "MyModel"
+license = "Apache-2.0"
+image_size = 224
+batch_size = 32
+output_classes = 2
+category = "image_classification"
+
+
+class MyModel(nn.Module):
+    def __init__(self, num_classes=output_classes):
+        super().__init__()
+        self.model = timm.create_model(
+            "convnextv2_tiny", pretrained=False, num_classes=num_classes
+        )
+
+    def forward(self, x):
+        return self.model(x)

--- a/model_zoo/image_classification/pytorch/dinov3.py
+++ b/model_zoo/image_classification/pytorch/dinov3.py
@@ -1,0 +1,28 @@
+"""DINOv3 backbone (Meta, Aug 2025) with a trainable linear head. Self-supervised ViT trained on 1.7B images; backbone is frozen so federated averaging only sees the small head — BN-free by construction."""
+import torch.nn as nn
+from transformers import AutoModel
+
+framework = "pytorch"
+main_class = "MyModel"
+license = "Apache-2.0"
+image_size = 224
+batch_size = 16
+output_classes = 2
+category = "image_classification"
+
+_BACKBONE_ID = "facebook/dinov3-vitb16-pretrain-lvd1689m"
+
+
+class MyModel(nn.Module):
+    def __init__(self, num_classes=output_classes):
+        super().__init__()
+        self.backbone = AutoModel.from_pretrained(_BACKBONE_ID)
+        for p in self.backbone.parameters():
+            p.requires_grad = False
+        hidden = self.backbone.config.hidden_size
+        self.head = nn.Linear(hidden, num_classes)
+
+    def forward(self, x):
+        out = self.backbone(pixel_values=x)
+        cls = out.last_hidden_state[:, 0]
+        return self.head(cls)

--- a/model_zoo/keypoint_detection/pytorch/vitpose.py
+++ b/model_zoo/keypoint_detection/pytorch/vitpose.py
@@ -1,0 +1,21 @@
+"""ViTPose (NeurIPS 2022). First transformer pose model in the zoo — ViT backbone + simple decoder; 81+ AP COCO whole-body at Huge scale, fine-tunes well at Base."""
+from transformers import VitPoseForPoseEstimation, VitPoseConfig
+
+framework = "pytorch"
+model_type = "transformer"
+main_method = "MyModel"
+license = "Apache-2.0"
+image_size = 256
+batch_size = 32
+output_classes = 1
+category = "keypoint_detection"
+num_feature_points = 17
+
+_PRETRAINED_ID = "usyd-community/vitpose-base-simple"
+
+
+def MyModel(num_feature_points=num_feature_points):
+    config = VitPoseConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_feature_points)
+    return VitPoseForPoseEstimation.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/object_detection/pytorch/rt_detr.py
+++ b/model_zoo/object_detection/pytorch/rt_detr.py
@@ -1,0 +1,20 @@
+"""RT-DETR (Baidu, CVPR 2024). First real-time DETR; Apache-2.0; ~53 AP COCO. Fills the entire transformer-detector gap left by the YOLO + Faster R-CNN lineup."""
+from transformers import RTDetrForObjectDetection, RTDetrConfig
+
+framework = "pytorch"
+model_type = "detr"
+main_method = "MyModel"
+license = "Apache-2.0"
+image_size = 640
+batch_size = 4
+output_classes = 12
+category = "object_detection"
+
+_PRETRAINED_ID = "PekingU/rtdetr_r50vd"
+
+
+def MyModel(num_classes=output_classes):
+    config = RTDetrConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+    return RTDetrForObjectDetection.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/semantic_segmentation/pytorch/fcn.py
+++ b/model_zoo/semantic_segmentation/pytorch/fcn.py
@@ -103,7 +103,7 @@ class FCN(nn.Module):
 class FCNResNet(nn.Module):
     """FCN with ResNet backbone - alternative implementation"""
     
-    def __init__(self, n_channels=3, n_classes=output_classes):
+    def __init__(self, n_channels=image_size, n_classes=output_classes):
         super(FCNResNet, self).__init__()
         self.n_channels = n_channels
         self.n_classes = n_classes

--- a/model_zoo/semantic_segmentation/pytorch/fcn.py
+++ b/model_zoo/semantic_segmentation/pytorch/fcn.py
@@ -103,7 +103,7 @@ class FCN(nn.Module):
 class FCNResNet(nn.Module):
     """FCN with ResNet backbone - alternative implementation"""
     
-    def __init__(self, n_channels=image_size, n_classes=output_classes):
+    def __init__(self, n_channels=3, n_classes=output_classes):
         super(FCNResNet, self).__init__()
         self.n_channels = n_channels
         self.n_classes = n_classes

--- a/model_zoo/semantic_segmentation/pytorch/hrnet.py
+++ b/model_zoo/semantic_segmentation/pytorch/hrnet.py
@@ -108,13 +108,11 @@ class HRModule(nn.Module):
 class HRNet(nn.Module):
     """HRNet for semantic segmentation"""
     
-    def __init__(self, n_channels=3, n_classes=output_classes, input_size=image_size, batch_size=batch_size):
+    def __init__(self, n_channels=3, n_classes=output_classes):
         super(HRNet, self).__init__()
         self.n_channels = n_channels
         self.n_classes = n_classes
-        self.input_size = input_size
-        self.batch_size = batch_size
-        
+
         # Initial convolution
         self.conv1 = nn.Conv2d(n_channels, 64, 3, stride=2, padding=1, bias=False)
         self.bn1 = nn.BatchNorm2d(64)

--- a/model_zoo/semantic_segmentation/pytorch/hrnet.py
+++ b/model_zoo/semantic_segmentation/pytorch/hrnet.py
@@ -108,10 +108,12 @@ class HRModule(nn.Module):
 class HRNet(nn.Module):
     """HRNet for semantic segmentation"""
     
-    def __init__(self, n_channels=3, n_classes=output_classes):
+    def __init__(self, n_channels=3, n_classes=output_classes, input_size=image_size, batch_size=batch_size):
         super(HRNet, self).__init__()
         self.n_channels = n_channels
         self.n_classes = n_classes
+        self.input_size = input_size
+        self.batch_size = batch_size
         
         # Initial convolution
         self.conv1 = nn.Conv2d(n_channels, 64, 3, stride=2, padding=1, bias=False)

--- a/model_zoo/semantic_segmentation/pytorch/mask2former.py
+++ b/model_zoo/semantic_segmentation/pytorch/mask2former.py
@@ -1,0 +1,19 @@
+"""Mask2Former (Meta, CVPR 2022). Dominant universal segmentation architecture — same model handles semantic / instance / panoptic via masked attention; ~57 mIoU ADE20K at Swin-L."""
+from transformers import Mask2FormerForUniversalSegmentation, Mask2FormerConfig
+
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+image_size = 384
+batch_size = 4
+output_classes = 2
+category = "semantic_segmentation"
+
+_PRETRAINED_ID = "facebook/mask2former-swin-tiny-ade-semantic"
+
+
+def MyModel(num_classes=output_classes):
+    config = Mask2FormerConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+    return Mask2FormerForUniversalSegmentation.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/tabular_classification/pytorch/mitra.py
+++ b/model_zoo/tabular_classification/pytorch/mitra.py
@@ -1,0 +1,16 @@
+"""Mitra (Amazon, NeurIPS 2025). Tabular foundation model — pretrained on synthetic priors; competitive with TabPFN v2 / CatBoost. Loaded via trust_remote_code so the HF repo supplies the architecture."""
+from transformers import AutoModel
+
+model_id = "autogluon/mitra-classifier"
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "tabular_classification"
+model_type = ""
+batch_size = 256
+num_feature_points = 50
+output_classes = 2
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModel.from_pretrained(model_id, trust_remote_code=True)

--- a/model_zoo/tabular_classification/pytorch/mitra.py
+++ b/model_zoo/tabular_classification/pytorch/mitra.py
@@ -1,7 +1,6 @@
-"""Mitra (Amazon, NeurIPS 2025). Tabular foundation model — pretrained on synthetic priors; competitive with TabPFN v2 / CatBoost. Loaded via trust_remote_code so the HF repo supplies the architecture."""
+"""Mitra (Amazon, NeurIPS 2025). Tabular foundation model — pretrained on synthetic priors; competitive with TabPFN v2 / CatBoost. Repo id is hard-coded as a string literal so the model-upload security gate (TBT001) recognises it against its vetted-repos allowlist."""
 from transformers import AutoModel
 
-model_id = "autogluon/mitra-classifier"
 framework = "pytorch"
 main_method = "MyModel"
 license = "Apache-2.0"
@@ -13,4 +12,4 @@ output_classes = 2
 
 
 def MyModel(num_classes=output_classes):
-    return AutoModel.from_pretrained(model_id, trust_remote_code=True)
+    return AutoModel.from_pretrained("autogluon/mitra-classifier", trust_remote_code=True)

--- a/model_zoo/tabular_classification/pytorch/mitra.py
+++ b/model_zoo/tabular_classification/pytorch/mitra.py
@@ -12,4 +12,8 @@ output_classes = 2
 
 
 def MyModel(num_classes=output_classes):
-    return AutoModel.from_pretrained("autogluon/mitra-classifier", trust_remote_code=True)
+    return AutoModel.from_pretrained(
+        "autogluon/mitra-classifier",
+        trust_remote_code=True,
+        num_classes=num_classes,
+    )

--- a/model_zoo/tabular_regression/pytorch/mitra.py
+++ b/model_zoo/tabular_regression/pytorch/mitra.py
@@ -1,0 +1,16 @@
+"""Mitra regressor (Amazon, NeurIPS 2025). Tabular foundation model for regression — pretrained on synthetic priors; loaded via trust_remote_code so the HF repo supplies the architecture."""
+from transformers import AutoModel
+
+model_id = "autogluon/mitra-regressor"
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "tabular_regression"
+model_type = ""
+batch_size = 256
+num_feature_points = 50
+output_classes = 1
+
+
+def MyModel():
+    return AutoModel.from_pretrained(model_id, trust_remote_code=True)

--- a/model_zoo/tabular_regression/pytorch/mitra.py
+++ b/model_zoo/tabular_regression/pytorch/mitra.py
@@ -1,7 +1,6 @@
-"""Mitra regressor (Amazon, NeurIPS 2025). Tabular foundation model for regression — pretrained on synthetic priors; loaded via trust_remote_code so the HF repo supplies the architecture."""
+"""Mitra regressor (Amazon, NeurIPS 2025). Tabular foundation model for regression — pretrained on synthetic priors. Repo id is hard-coded as a string literal so the model-upload security gate (TBT001) recognises it against its vetted-repos allowlist."""
 from transformers import AutoModel
 
-model_id = "autogluon/mitra-regressor"
 framework = "pytorch"
 main_method = "MyModel"
 license = "Apache-2.0"
@@ -13,4 +12,4 @@ output_classes = 1
 
 
 def MyModel():
-    return AutoModel.from_pretrained(model_id, trust_remote_code=True)
+    return AutoModel.from_pretrained("autogluon/mitra-regressor", trust_remote_code=True)

--- a/model_zoo/text_classification/pytorch/eurobert.py
+++ b/model_zoo/text_classification/pytorch/eurobert.py
@@ -1,7 +1,6 @@
-"""EuroBERT-210M (2025). Multilingual encoder covering 15 European languages, 8192 context; closes the multilingual gap left by the BERT/RoBERTa lineup. Loads via trust_remote_code."""
+"""EuroBERT-210M (2025). Multilingual encoder covering 15 European languages, 8192 context; closes the multilingual gap left by the BERT/RoBERTa lineup. Loads via trust_remote_code — the repo id is hard-coded as a string literal so the model-upload security gate (TBT001) recognises it against its vetted-repos allowlist."""
 from transformers import AutoModelForSequenceClassification
 
-model_id = "EuroBERT/EuroBERT-210m"
 framework = "pytorch"
 main_method = "MyModel"
 license = "Apache-2.0"
@@ -14,7 +13,7 @@ output_classes = 5
 
 def MyModel(num_classes=output_classes):
     return AutoModelForSequenceClassification.from_pretrained(
-        model_id,
+        "EuroBERT/EuroBERT-210m",
         num_labels=num_classes,
         trust_remote_code=True,
         ignore_mismatched_sizes=True,

--- a/model_zoo/text_classification/pytorch/eurobert.py
+++ b/model_zoo/text_classification/pytorch/eurobert.py
@@ -1,0 +1,21 @@
+"""EuroBERT-210M (2025). Multilingual encoder covering 15 European languages, 8192 context; closes the multilingual gap left by the BERT/RoBERTa lineup. Loads via trust_remote_code."""
+from transformers import AutoModelForSequenceClassification
+
+model_id = "EuroBERT/EuroBERT-210m"
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "text_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 512
+output_classes = 5
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForSequenceClassification.from_pretrained(
+        model_id,
+        num_labels=num_classes,
+        trust_remote_code=True,
+        ignore_mismatched_sizes=True,
+    )

--- a/model_zoo/text_classification/pytorch/modernbert.py
+++ b/model_zoo/text_classification/pytorch/modernbert.py
@@ -1,0 +1,18 @@
+"""ModernBERT (Answer.AI / LightOn, Dec 2024). Drop-in BERT replacement — 8192-token context, ~3x training speed, strong on classification + retrieval."""
+from transformers import AutoModelForSequenceClassification
+
+model_id = "answerdotai/ModernBERT-base"
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "text_classification"
+model_type = ""
+batch_size = 64
+sequence_length = 512
+output_classes = 5
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForSequenceClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/time_series_forecasting/pytorch/chronos_bolt.py
+++ b/model_zoo/time_series_forecasting/pytorch/chronos_bolt.py
@@ -14,4 +14,4 @@ forecast_horizon = 64
 
 
 def MyModel():
-    return AutoModelForSeq2SeqLM.from_pretrained(model_id)
+    return AutoModelForSeq2SeqLM.from_pretrained(model_id, trust_remote_code=True)

--- a/model_zoo/time_series_forecasting/pytorch/chronos_bolt.py
+++ b/model_zoo/time_series_forecasting/pytorch/chronos_bolt.py
@@ -1,0 +1,17 @@
+"""Chronos-Bolt (Amazon, 2024). T5-based time-series foundation model — Apache-2.0, fine-tunes via standard seq2seq. Loaded directly through transformers to avoid pulling in chronos-forecasting."""
+from transformers import AutoModelForSeq2SeqLM
+
+model_id = "amazon/chronos-bolt-base"
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "time_series_forecasting"
+model_type = ""
+batch_size = 32
+num_feature_points = 1
+sequence_length = 512
+forecast_horizon = 64
+
+
+def MyModel():
+    return AutoModelForSeq2SeqLM.from_pretrained(model_id)

--- a/model_zoo/time_to_event_prediction/scikit_survival/random_survival_forest.py
+++ b/model_zoo/time_to_event_prediction/scikit_survival/random_survival_forest.py
@@ -1,0 +1,17 @@
+"""Random Survival Forest (Ishwaran et al., 2008) via scikit-survival. Tree-based non-parametric survival baseline — handles non-linear effects and interactions without the proportional-hazards assumption."""
+from sksurv.ensemble import RandomSurvivalForest
+
+framework = "scikit_survival"
+model_type = ""
+main_method = "MyModel"
+license = "GPL-3.0"
+batch_size = 128
+output_classes = 1
+category = "time_to_event_prediction"
+num_feature_points = 12
+
+
+def MyModel():
+    return RandomSurvivalForest(
+        n_estimators=100, min_samples_split=10, min_samples_leaf=15, n_jobs=-1
+    )


### PR DESCRIPTION
## Summary

Closes the most prominent gaps surfaced by the late-2025 architecture audit. Each new file follows the existing single-file template (framework metadata, `main_class` / `main_method`, task-specific fields) plus the new `license` field convention.

### New models

| Task | File | Source / loader |
|---|---|---|
| image_classification | `convnext_v2.py` | `timm.create_model("convnextv2_tiny")` |
| image_classification | `dinov3.py` | `transformers AutoModel` frozen backbone + linear head |
| object_detection | `rt_detr.py` | `transformers.RTDetrForObjectDetection` |
| semantic_segmentation | `mask2former.py` | `transformers.Mask2FormerForUniversalSegmentation` |
| keypoint_detection | `vitpose.py` | `transformers.VitPoseForPoseEstimation` |
| text_classification | `modernbert.py` | `answerdotai/ModernBERT-base` |
| text_classification | `eurobert.py` | `EuroBERT/EuroBERT-210m` (multilingual, `trust_remote_code`) |
| tabular_classification | `mitra.py` | `autogluon/mitra-classifier` (foundation model) |
| tabular_regression | `mitra.py` | `autogluon/mitra-regressor` |
| time_series_forecasting | `chronos_bolt.py` | `amazon/chronos-bolt-base` (T5 via transformers) |
| time_to_event_prediction | `random_survival_forest.py` | `sksurv.ensemble.RandomSurvivalForest` |

### CLAUDE.md updates

- Adds optional `license` SPDX-style metadata field so downstream tooling can filter models by license.
- New "Federated averaging conventions" section: BatchNorm handling, EMA buffers, LoRA-only fine-tuning for foundation models.

### Infra prerequisites (separate PRs in tracebloc-client / averaging-service)

- DINOv3 requires `transformers >= 4.56`. Existing infra is pinned to `4.51.3`; that bump is being handled separately. If shipping ahead of the bump, swap DINOv3 → DINOv2.
- All other models work on `transformers == 4.51.3`.

## Test plan

- [ ] CI passes (`ruff`, `pytest` matrix across pytorch / tensorflow / sklearn / survival jobs).
- [ ] Each new file passes `tests/test_model_contract.py` in the pytorch job (the CI matrix installs latest `transformers`, which has RT-DETR + ViTPose).
- [ ] In the training container (`transformers==4.51.3`), run `from tracebloc_package import User; User().uploadModel(<path>)` for each new file to confirm the SDK forward-pass check.
- [ ] Verify averaging-service can deserialize a checkpoint from one of the foundation models (Mitra or Chronos-Bolt) when LoRA-only fine-tuning is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive model templates, but several new entries load Hugging Face models with `trust_remote_code=True` and introduce new third-party dependencies/model IDs that can affect security review and runtime compatibility.
> 
> **Overview**
> Adds a set of new single-file model templates across task families (image classification, detection, segmentation, keypoints, text, tabular, time-series, and survival), primarily by loading pretrained backbones from `transformers` (plus `timm` for ConvNeXtV2) and exposing them via the existing `main_class`/`main_method` contract.
> 
> Updates `CLAUDE.md` to recommend a new `license` metadata field and to document *federated-averaging-oriented* authoring conventions (BatchNorm/EMA handling and LoRA-only fine-tuning for large backbones).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4555c12b1915c4e6e211516b679316b1aed2cb31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->