### PR TITLE
Add 9 trending models across 5 existing task families (round 3)

### DIFF
--- a/model_zoo/image_classification/pytorch/eva_02.py
+++ b/model_zoo/image_classification/pytorch/eva_02.py
@@ -1,0 +1,24 @@
+"""EVA-02 via timm. First open vision backbone past 90% ImageNet top-1 — ViT + SwiGLU + RoPE + masked-image-modeling pretraining. Base variant is the practical default."""
+import timm
+import torch.nn as nn
+
+framework = "pytorch"
+main_class = "MyModel"
+license = "MIT"
+image_size = 448
+batch_size = 16
+output_classes = 2
+category = "image_classification"
+
+
+class MyModel(nn.Module):
+    def __init__(self, num_classes=output_classes):
+        super().__init__()
+        self.model = timm.create_model(
+            "eva02_base_patch14_448.mim_in22k_ft_in22k_in1k",
+            pretrained=False,
+            num_classes=num_classes,
+        )
+
+    def forward(self, x):
+        return self.model(x)

--- a/model_zoo/image_classification/pytorch/fastvit.py
+++ b/model_zoo/image_classification/pytorch/fastvit.py
@@ -1,0 +1,22 @@
+"""FastViT (Apple, ICCV 2023) via timm. Hybrid conv + transformer designed for mobile latency — 1.9–4.9× faster than ConvNeXt at comparable accuracy. Fills the modern-efficient gap (squeezenet is the only other lightweight option in the zoo)."""
+import timm
+import torch.nn as nn
+
+framework = "pytorch"
+main_class = "MyModel"
+license = "Apple-Sample-Code-License"
+image_size = 256
+batch_size = 64
+output_classes = 2
+category = "image_classification"
+
+
+class MyModel(nn.Module):
+    def __init__(self, num_classes=output_classes):
+        super().__init__()
+        self.model = timm.create_model(
+            "fastvit_s12.apple_in1k", pretrained=False, num_classes=num_classes
+        )
+
+    def forward(self, x):
+        return self.model(x)

--- a/model_zoo/image_classification/pytorch/hiera.py
+++ b/model_zoo/image_classification/pytorch/hiera.py
@@ -1,0 +1,19 @@
+"""Hiera (Meta, ICML 2023). Hierarchical ViT that strips per-stage tricks (relative position, conv stem, etc.) while matching Swin/MViTv2 accuracy. Simpler architecture, MAE-pretrained, available via transformers."""
+from transformers import HieraForImageClassification, HieraConfig
+
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+image_size = 224
+batch_size = 32
+output_classes = 2
+category = "image_classification"
+
+_PRETRAINED_ID = "facebook/hiera-tiny-224-in1k-hf"
+
+
+def MyModel(num_classes=output_classes):
+    config = HieraConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+    return HieraForImageClassification.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/semantic_segmentation/pytorch/dpt.py
+++ b/model_zoo/semantic_segmentation/pytorch/dpt.py
@@ -1,0 +1,19 @@
+"""DPT — Dense Prediction Transformer (Intel ISL, ICCV 2021). ViT backbone with a dense prediction head; primarily known for depth but the semantic-segmentation variant is a strong reference baseline on ADE20K."""
+from transformers import DPTForSemanticSegmentation, DPTConfig
+
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+image_size = 480
+batch_size = 4
+output_classes = 2
+category = "semantic_segmentation"
+
+_PRETRAINED_ID = "Intel/dpt-large-ade"
+
+
+def MyModel(num_classes=output_classes):
+    config = DPTConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+    return DPTForSemanticSegmentation.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/semantic_segmentation/pytorch/upernet.py
+++ b/model_zoo/semantic_segmentation/pytorch/upernet.py
@@ -1,0 +1,19 @@
+"""UPerNet (ECCV 2018). PPM + FPN decoder paired here with a ConvNeXt backbone. The canonical decoder used in modern segmentation papers when reporting ConvNeXt / Swin results — strong, well-understood baseline."""
+from transformers import UperNetForSemanticSegmentation, UperNetConfig
+
+framework = "pytorch"
+main_method = "MyModel"
+license = "MIT"
+image_size = 512
+batch_size = 4
+output_classes = 2
+category = "semantic_segmentation"
+
+_PRETRAINED_ID = "openmmlab/upernet-convnext-small"
+
+
+def MyModel(num_classes=output_classes):
+    config = UperNetConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+    return UperNetForSemanticSegmentation.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/text_classification/pytorch/electra.py
+++ b/model_zoo/text_classification/pytorch/electra.py
@@ -1,0 +1,18 @@
+"""ELECTRA (Stanford / Google, ICLR 2020). Replaced-token-detection pretraining — same compute, consistently better downstream accuracy than BERT/RoBERTa at small scale. Strong baseline when training-data budget is tight."""
+from transformers import AutoModelForSequenceClassification
+
+model_id = "google/electra-base-discriminator"
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "text_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 512
+output_classes = 5
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForSequenceClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/text_classification/pytorch/longformer.py
+++ b/model_zoo/text_classification/pytorch/longformer.py
@@ -1,0 +1,18 @@
+"""Longformer (AllenAI, 2020). Sparse local + global attention — supports 4096-token context with linear-in-length compute. The reference choice for long-document classification (legal, medical, financial filings)."""
+from transformers import AutoModelForSequenceClassification
+
+model_id = "allenai/longformer-base-4096"
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "text_classification"
+model_type = ""
+batch_size = 8
+sequence_length = 4096
+output_classes = 5
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForSequenceClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/time_series_forecasting/pytorch/patch_tsmixer.py
+++ b/model_zoo/time_series_forecasting/pytorch/patch_tsmixer.py
@@ -1,0 +1,26 @@
+"""PatchTSMixer (IBM, KDD 2023). MLP-Mixer architecture for time series — patches + channel mixing without attention. Competitive with PatchTST at a fraction of the compute; the strong "do you even need a transformer" baseline."""
+from transformers import PatchTSMixerConfig, PatchTSMixerForPrediction
+
+framework = "pytorch"
+main_method = "MyModel"
+license = "Apache-2.0"
+category = "time_series_forecasting"
+batch_size = 64
+num_feature_points = 9
+sequence_length = 96
+forecast_horizon = 24
+
+
+def MyModel():
+    config = PatchTSMixerConfig(
+        num_input_channels=num_feature_points,
+        context_length=sequence_length,
+        prediction_length=forecast_horizon,
+        patch_length=8,
+        patch_stride=8,
+        d_model=64,
+        expansion_factor=2,
+        num_layers=3,
+        dropout=0.2,
+    )
+    return PatchTSMixerForPrediction(config)

--- a/model_zoo/time_to_event_prediction/scikit_survival/gradient_boosted_survival.py
+++ b/model_zoo/time_to_event_prediction/scikit_survival/gradient_boosted_survival.py
@@ -1,0 +1,17 @@
+"""Gradient Boosted Survival (scikit-survival). Boosted-trees survival analysis — boosted sibling of Random Survival Forest; often beats deep models on tabular medical data with small-to-medium sample sizes."""
+from sksurv.ensemble import GradientBoostingSurvivalAnalysis
+
+framework = "scikit_survival"
+model_type = ""
+main_method = "MyModel"
+license = "GPL-3.0"
+batch_size = 128
+output_classes = 1
+category = "time_to_event_prediction"
+num_feature_points = 12
+
+
+def MyModel():
+    return GradientBoostingSurvivalAnalysis(
+        n_estimators=100, learning_rate=0.1, max_depth=3
+    )


### PR DESCRIPTION
## Summary

Round 3 of the architecture audit. Broadens coverage in existing task families using libraries already installed in the training container — **zero new dependencies, zero infra PRs required**.

### New models

| Task | File | Loader | License |
|---|---|---|---|
| image_classification | `eva_02.py` | `timm` `eva02_base_patch14_448` | MIT |
| image_classification | `fastvit.py` | `timm` `fastvit_s12` | Apple-Sample-Code |
| image_classification | `hiera.py` | `transformers.HieraForImageClassification` | Apache-2.0 |
| semantic_segmentation | `dpt.py` | `transformers.DPTForSemanticSegmentation` | Apache-2.0 |
| semantic_segmentation | `upernet.py` | `transformers.UperNetForSemanticSegmentation` | MIT |
| text_classification | `electra.py` | `google/electra-base-discriminator` | Apache-2.0 |
| text_classification | `longformer.py` | `allenai/longformer-base-4096` (4096-token context) | Apache-2.0 |
| time_series_forecasting | `patch_tsmixer.py` | `transformers.PatchTSMixerForPrediction` | Apache-2.0 |
| time_to_event_prediction | `gradient_boosted_survival.py` | `sksurv.ensemble.GradientBoostingSurvivalAnalysis` | GPL-3.0 |

### Why these

- **EVA-02** — first open >90% ImageNet model; the obvious "max accuracy backbone you can self-host" answer.
- **FastViT** — fills the modern-efficient gap; the zoo had nothing recent in the mobile / edge size class.
- **Hiera** — simpler hierarchical ViT alternative to Swin / MaxViT, MAE-pretrained.
- **DPT + UPerNet** — round out the semantic segmentation lineup with two well-understood baselines (we already have Mask2Former and SegFormer from rounds 1/2A).
- **ELECTRA** — different pretraining objective from BERT/RoBERTa/ModernBERT; consistently better in compute-tight regimes.
- **Longformer** — closes the long-context gap (existing text models cap at 512–1024 tokens; this is 4096) for legal / medical / financial documents.
- **PatchTSMixer** — the "do you even need a transformer for time series" answer; pairs with PatchTST (added in round 2A).
- **Gradient Boosted Survival** — boosted-trees sibling of Random Survival Forest (added in round 1); often beats deep models on tabular medical data.

### Infra requirements

All models load via libraries pinned in `tracebloc-client/use_cases/requirements*.txt`:
- `timm==1.0.15` — EVA-02, FastViT
- `transformers==4.51.3` — Hiera (needs 4.45+ ✓), DPT, UperNet, ELECTRA, Longformer, PatchTSMixer (needs 4.40+ ✓)
- `scikit-survival==0.24.0` — Gradient Boosted Survival

No version bumps needed.

## Test plan

- [ ] CI ruff + pytest matrix passes (CI installs latest `transformers` + `timm`, so all 9 will run their full contract check there).
- [ ] In the training container, run `from tracebloc_package import User; User().uploadModel(<path>)` for each new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive model-zoo entries, but introduces several `from_pretrained` loaders (runtime network/model-asset behavior) and a new GPL-3.0 licensed scikit-survival model that may have distribution/compliance implications.
> 
> **Overview**
> Adds **nine new model-zoo definitions** across existing task families: image classification (`eva_02`, `fastvit`, `hiera`), semantic segmentation (`dpt`, `upernet`), text classification (`electra`, `longformer` with 4096-token context), time-series forecasting (`patch_tsmixer`), and time-to-event prediction (`gradient_boosted_survival`).
> 
> The new entries standardize metadata (e.g., `image_size`, `batch_size`, `output_classes`, license) and instantiate models via `timm`, Hugging Face `transformers` `from_pretrained(..., ignore_mismatched_sizes=True)`, or `sksurv`’s `GradientBoostingSurvivalAnalysis`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3492e5922f2a97fcecb455e2f6fb38760d780b78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->