### PR TITLE
Add 8 models across detection, keypoint, and tabular (round 4)

### DIFF
--- a/model_zoo/keypoint_detection/pytorch/keypoint_rcnn.py
+++ b/model_zoo/keypoint_detection/pytorch/keypoint_rcnn.py
@@ -1,6 +1,7 @@
 """Keypoint R-CNN (Meta, ICCV 2017). Mask R-CNN architecture with a keypoint head — top-down multi-person pose via a two-stage detector. Reference torchvision-native baseline for multi-person keypoint detection."""
 import torchvision
 from torchvision.models.detection import KeypointRCNN_ResNet50_FPN_Weights
+from torchvision.models.detection.keypoint_rcnn import KeypointRCNNPredictor
 
 framework = "pytorch"
 model_type = "rcnn"
@@ -14,8 +15,17 @@ num_feature_points = 17
 
 
 def MyModel(num_feature_points=num_feature_points):
-    return torchvision.models.detection.keypointrcnn_resnet50_fpn(
-        weights=KeypointRCNN_ResNet50_FPN_Weights.DEFAULT,
-        num_keypoints=num_feature_points,
-        weights_backbone=None,
+    # torchvision's detection builders raise ValueError when a non-default
+    # num_keypoints is paired with COCO pretrained weights (the weights
+    # expect 17 keypoints). Load with the pretrained weights' default head,
+    # then swap the keypoint predictor for one sized to the caller's
+    # num_feature_points — mirrors the head-swap pattern used by
+    # object_detection/pytorch/fcos.py and retinanet.py.
+    model = torchvision.models.detection.keypointrcnn_resnet50_fpn(
+        weights=KeypointRCNN_ResNet50_FPN_Weights.DEFAULT
     )
+    in_channels = model.roi_heads.keypoint_predictor.kps_score_lowres.in_channels
+    model.roi_heads.keypoint_predictor = KeypointRCNNPredictor(
+        in_channels, num_feature_points
+    )
+    return model

--- a/model_zoo/keypoint_detection/pytorch/keypoint_rcnn.py
+++ b/model_zoo/keypoint_detection/pytorch/keypoint_rcnn.py
@@ -1,0 +1,21 @@
+"""Keypoint R-CNN (Meta, ICCV 2017). Mask R-CNN architecture with a keypoint head — top-down multi-person pose via a two-stage detector. Reference torchvision-native baseline for multi-person keypoint detection."""
+import torchvision
+from torchvision.models.detection import KeypointRCNN_ResNet50_FPN_Weights
+
+framework = "pytorch"
+model_type = "rcnn"
+main_method = "MyModel"
+license = "BSD-3-Clause"
+image_size = 448
+batch_size = 4
+output_classes = 1
+category = "keypoint_detection"
+num_feature_points = 17
+
+
+def MyModel(num_feature_points=num_feature_points):
+    return torchvision.models.detection.keypointrcnn_resnet50_fpn(
+        weights=KeypointRCNN_ResNet50_FPN_Weights.DEFAULT,
+        num_keypoints=num_feature_points,
+        weights_backbone=None,
+    )

--- a/model_zoo/object_detection/pytorch/deformable_detr.py
+++ b/model_zoo/object_detection/pytorch/deformable_detr.py
@@ -1,0 +1,20 @@
+"""Deformable DETR (SenseTime, ICLR 2021). Multi-scale deformable attention — 10x faster convergence than vanilla DETR and stronger on small objects. The bridge between DETR (2020) and RT-DETR (2024)."""
+from transformers import DeformableDetrForObjectDetection, DeformableDetrConfig
+
+framework = "pytorch"
+model_type = "detr"
+main_method = "MyModel"
+license = "Apache-2.0"
+image_size = 800
+batch_size = 4
+output_classes = 12
+category = "object_detection"
+
+_PRETRAINED_ID = "SenseTime/deformable-detr"
+
+
+def MyModel(num_classes=output_classes):
+    config = DeformableDetrConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+    return DeformableDetrForObjectDetection.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/object_detection/pytorch/detr.py
+++ b/model_zoo/object_detection/pytorch/detr.py
@@ -1,0 +1,20 @@
+"""DETR (Meta, ECCV 2020). The original transformer detector — set-prediction with Hungarian matching. Historical reference; pairs with RT-DETR (efficient) and Grounding DINO (open-vocabulary)."""
+from transformers import DetrForObjectDetection, DetrConfig
+
+framework = "pytorch"
+model_type = "detr"
+main_method = "MyModel"
+license = "Apache-2.0"
+image_size = 800
+batch_size = 4
+output_classes = 12
+category = "object_detection"
+
+_PRETRAINED_ID = "facebook/detr-resnet-50"
+
+
+def MyModel(num_classes=output_classes):
+    config = DetrConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+    return DetrForObjectDetection.from_pretrained(
+        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/object_detection/pytorch/fcos.py
+++ b/model_zoo/object_detection/pytorch/fcos.py
@@ -1,6 +1,7 @@
 """FCOS (ICCV 2019). Anchor-free one-stage detector — predicts boxes per-pixel via center-ness, much simpler than anchor-based two-stage approaches. Strong baseline for production deployments."""
 import torchvision
 from torchvision.models.detection import FCOS_ResNet50_FPN_Weights
+from torchvision.models.detection.fcos import FCOSClassificationHead
 
 framework = "pytorch"
 model_type = "fcos"
@@ -14,8 +15,18 @@ category = "object_detection"
 
 def MyModel(num_classes=output_classes):
     num_classes = num_classes + 1  # 1 for background
-    return torchvision.models.detection.fcos_resnet50_fpn(
-        weights=FCOS_ResNet50_FPN_Weights.DEFAULT,
-        num_classes=num_classes,
-        weights_backbone=None,
+
+    # torchvision's detection builders raise ValueError when a custom
+    # num_classes is paired with COCO pretrained weights (the weights expect
+    # 91 classes). Load with the pretrained weights' default head, then swap
+    # the classification head for one sized to the caller's num_classes —
+    # mirrors the pattern in faster_rcnn_resnet.py.
+    model = torchvision.models.detection.fcos_resnet50_fpn(
+        weights=FCOS_ResNet50_FPN_Weights.DEFAULT
     )
+    in_channels = model.backbone.out_channels
+    num_anchors = model.head.classification_head.num_anchors
+    model.head.classification_head = FCOSClassificationHead(
+        in_channels, num_anchors, num_classes
+    )
+    return model

--- a/model_zoo/object_detection/pytorch/fcos.py
+++ b/model_zoo/object_detection/pytorch/fcos.py
@@ -1,0 +1,21 @@
+"""FCOS (ICCV 2019). Anchor-free one-stage detector — predicts boxes per-pixel via center-ness, much simpler than anchor-based two-stage approaches. Strong baseline for production deployments."""
+import torchvision
+from torchvision.models.detection import FCOS_ResNet50_FPN_Weights
+
+framework = "pytorch"
+model_type = "fcos"
+main_method = "MyModel"
+license = "BSD-3-Clause"
+image_size = 448
+batch_size = 8
+output_classes = 12
+category = "object_detection"
+
+
+def MyModel(num_classes=output_classes):
+    num_classes = num_classes + 1  # 1 for background
+    return torchvision.models.detection.fcos_resnet50_fpn(
+        weights=FCOS_ResNet50_FPN_Weights.DEFAULT,
+        num_classes=num_classes,
+        weights_backbone=None,
+    )

--- a/model_zoo/object_detection/pytorch/retinanet.py
+++ b/model_zoo/object_detection/pytorch/retinanet.py
@@ -1,0 +1,21 @@
+"""RetinaNet (Meta, ICCV 2017). Focal loss + one-stage anchor design — the canonical one-stage detector still widely deployed for production. Pairs with Faster R-CNN as the standard two-stage / one-stage comparison."""
+import torchvision
+from torchvision.models.detection import RetinaNet_ResNet50_FPN_Weights
+
+framework = "pytorch"
+model_type = "retinanet"
+main_method = "MyModel"
+license = "BSD-3-Clause"
+image_size = 448
+batch_size = 8
+output_classes = 12
+category = "object_detection"
+
+
+def MyModel(num_classes=output_classes):
+    num_classes = num_classes + 1  # 1 for background
+    return torchvision.models.detection.retinanet_resnet50_fpn(
+        weights=RetinaNet_ResNet50_FPN_Weights.DEFAULT,
+        num_classes=num_classes,
+        weights_backbone=None,
+    )

--- a/model_zoo/object_detection/pytorch/retinanet.py
+++ b/model_zoo/object_detection/pytorch/retinanet.py
@@ -1,6 +1,7 @@
 """RetinaNet (Meta, ICCV 2017). Focal loss + one-stage anchor design — the canonical one-stage detector still widely deployed for production. Pairs with Faster R-CNN as the standard two-stage / one-stage comparison."""
 import torchvision
 from torchvision.models.detection import RetinaNet_ResNet50_FPN_Weights
+from torchvision.models.detection.retinanet import RetinaNetClassificationHead
 
 framework = "pytorch"
 model_type = "retinanet"
@@ -14,8 +15,18 @@ category = "object_detection"
 
 def MyModel(num_classes=output_classes):
     num_classes = num_classes + 1  # 1 for background
-    return torchvision.models.detection.retinanet_resnet50_fpn(
-        weights=RetinaNet_ResNet50_FPN_Weights.DEFAULT,
-        num_classes=num_classes,
-        weights_backbone=None,
+
+    # torchvision's detection builders raise ValueError when a custom
+    # num_classes is paired with COCO pretrained weights (the weights expect
+    # 91 classes). Load with the pretrained weights' default head, then swap
+    # the classification head for one sized to the caller's num_classes —
+    # mirrors the pattern in faster_rcnn_resnet.py.
+    model = torchvision.models.detection.retinanet_resnet50_fpn(
+        weights=RetinaNet_ResNet50_FPN_Weights.DEFAULT
     )
+    in_channels = model.backbone.out_channels
+    num_anchors = model.head.classification_head.num_anchors
+    model.head.classification_head = RetinaNetClassificationHead(
+        in_channels, num_anchors, num_classes
+    )
+    return model

--- a/model_zoo/tabular_classification/sklearn/hist_gradient_boosting_classifier.py
+++ b/model_zoo/tabular_classification/sklearn/hist_gradient_boosting_classifier.py
@@ -1,0 +1,15 @@
+"""Histogram-based Gradient Boosting classifier (sklearn). Modern GBDT — ~10x faster than classic GradientBoosting, handles missing values natively, supports native categorical encoding. The sklearn answer to LightGBM."""
+from sklearn.ensemble import HistGradientBoostingClassifier
+
+framework = "sklearn"
+model_type = "tree"
+main_method = "MyModel"
+license = "BSD-3-Clause"
+batch_size = 4096
+output_classes = 2
+num_feature_points = 50
+category = "tabular_classification"
+
+
+def MyModel():
+    return HistGradientBoostingClassifier()

--- a/model_zoo/tabular_regression/sklearn/hist_gradient_boosting_regressor.py
+++ b/model_zoo/tabular_regression/sklearn/hist_gradient_boosting_regressor.py
@@ -1,0 +1,15 @@
+"""Histogram-based Gradient Boosting regressor (sklearn). Modern GBDT — ~10x faster than classic GradientBoosting, handles missing values natively, supports native categorical encoding. Pure-sklearn alternative to LightGBM."""
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+framework = "sklearn"
+model_type = "tree"
+main_method = "MyModel"
+license = "BSD-3-Clause"
+batch_size = 4096
+output_classes = 1
+num_feature_points = 50
+category = "tabular_regression"
+
+
+def MyModel():
+    return HistGradientBoostingRegressor()

--- a/model_zoo/tabular_regression/sklearn/tweedie_regressor.py
+++ b/model_zoo/tabular_regression/sklearn/tweedie_regressor.py
@@ -1,0 +1,15 @@
+"""Tweedie GLM regressor (sklearn). Exponential dispersion family — the canonical model for non-negative, right-skewed targets with a mass at zero. Standard for insurance claims, healthcare costs, energy consumption."""
+from sklearn.linear_model import TweedieRegressor
+
+framework = "sklearn"
+model_type = "linear"
+main_method = "MyModel"
+license = "BSD-3-Clause"
+batch_size = 4096
+output_classes = 1
+num_feature_points = 50
+category = "tabular_regression"
+
+
+def MyModel():
+    return TweedieRegressor(power=1.5, alpha=0.5, link="log", max_iter=1000)


### PR DESCRIPTION
## Summary

Round 4 of the architecture audit. Covers the four task families left untouched in round 3 (object_detection, keypoint_detection, tabular_classification, tabular_regression). **Zero new dependencies** — all torchvision / transformers / sklearn natives already pinned in the training container.

### New models

| Task | File | Source | License |
|---|---|---|---|
| object_detection | `detr.py` | `transformers.DetrForObjectDetection` | Apache-2.0 |
| object_detection | `deformable_detr.py` | `transformers.DeformableDetrForObjectDetection` | Apache-2.0 |
| object_detection | `fcos.py` | `torchvision.models.detection.fcos_resnet50_fpn` | BSD-3-Clause |
| object_detection | `retinanet.py` | `torchvision.models.detection.retinanet_resnet50_fpn` | BSD-3-Clause |
| keypoint_detection | `keypoint_rcnn.py` | `torchvision.models.detection.keypointrcnn_resnet50_fpn` | BSD-3-Clause |
| tabular_classification | `sklearn/hist_gradient_boosting_classifier.py` | `sklearn.ensemble.HistGradientBoostingClassifier` | BSD-3-Clause |
| tabular_regression | `sklearn/hist_gradient_boosting_regressor.py` | `sklearn.ensemble.HistGradientBoostingRegressor` | BSD-3-Clause |
| tabular_regression | `sklearn/tweedie_regressor.py` | `sklearn.linear_model.TweedieRegressor` | BSD-3-Clause |

### Why these

- **DETR + Deformable DETR** — historical reference (DETR) and the architectural bridge (Deformable DETR) to RT-DETR which we already ship. Closes the family lineage.
- **FCOS + RetinaNet** — anchor-free and focal-loss one-stage baselines. Torchvision-native, no transformer needed. Strong production-default choices.
- **Keypoint R-CNN** — the canonical torchvision-native multi-person pose baseline; companion to existing Mask R-CNN.
- **HistGradientBoosting (classifier + regressor)** — sklearn's modern histogram GBDT: ~10× faster than classic `GradientBoosting{Classifier,Regressor}`, handles missing values natively. Meaningfully different from the existing `gbm.py` / `gradient_boosting.py`.
- **TweedieRegressor** — GLM for exponential dispersion family (non-negative, right-skewed, mass at zero). The canonical fit for insurance claims and healthcare cost data — exactly tracebloc's federated-finance / federated-healthcare audience.

### What stays out

- Anomaly detection / depth / vision-language — new task families, dependent on use-case container support in other repos.
- iTransformer (`neuralforecast`), RTMPose (`mmpose`) — single-model new-dep additions, defer until customer need.
- Sapiens (Meta human foundation model) — needs `trust_remote_code=True`; would require backend allowlist update.

## Test plan

- [ ] CI ruff + pytest matrix passes (all 8 ran their full contract check locally: 107 passed, 15 skipped).
- [ ] In the training container, run `from tracebloc_package import User; User().uploadModel(<path>)` for each new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new model definition files without modifying existing training/runtime logic. Main risk is runtime compatibility (e.g., pretrained weight downloads and head-size swaps for custom class/keypoint counts).
> 
> **Overview**
> Adds **8 new `model_zoo` model definitions** spanning *object detection* (DETR, Deformable DETR, FCOS, RetinaNet), *keypoint detection* (Keypoint R-CNN), and *tabular* tasks (sklearn histogram gradient boosting classifier/regressor and Tweedie regressor).
> 
> Torchvision detection models (`fcos`, `retinanet`, `keypoint_rcnn`) load COCO pretrained weights and then **swap the prediction heads** to support caller-provided class/keypoint counts, while the transformers-based DETR variants instantiate from pretrained IDs with `ignore_mismatched_sizes=True` to allow custom label counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd6ba35b47b4bd996cebb7f5d8227fda9b1f4dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->