### PR TITLE
Remove in-file PEFT/LoRA wrappers from text-classification models

### DIFF
--- a/model_zoo/text_classification/pytorch/electra.py
+++ b/model_zoo/text_classification/pytorch/electra.py
@@ -1,5 +1,4 @@
-"""ELECTRA (Stanford / Google, ICLR 2020). Replaced-token-detection pretraining — same compute, consistently better downstream accuracy than BERT/RoBERTa at small scale. Strong baseline when training-data budget is tight. Fine-tuned LoRA-only so federated averaging only syncs the small adapter tensors."""
-from peft import LoraConfig, TaskType, get_peft_model
+"""ELECTRA (Stanford / Google, ICLR 2020). Replaced-token-detection pretraining — same compute, consistently better downstream accuracy than BERT/RoBERTa at small scale. Strong baseline when training-data budget is tight. Select LoRA-only fine-tuning in the training plan if you want federated averaging to sync only the adapter tensors."""
 from transformers import AutoModelForSequenceClassification
 
 model_id = "google/electra-base-discriminator"
@@ -14,16 +13,6 @@ output_classes = 5
 
 
 def MyModel(num_classes=output_classes):
-    base = AutoModelForSequenceClassification.from_pretrained(
+    return AutoModelForSequenceClassification.from_pretrained(
         model_id, num_labels=num_classes, ignore_mismatched_sizes=True
     )
-    lora_config = LoraConfig(
-        task_type=TaskType.SEQ_CLS,
-        r=8,
-        lora_alpha=16,
-        lora_dropout=0.1,
-        bias="none",
-        target_modules=["query", "key", "value"],
-        modules_to_save=["classifier"],
-    )
-    return get_peft_model(base, lora_config)

--- a/model_zoo/text_classification/pytorch/gemma_2.py
+++ b/model_zoo/text_classification/pytorch/gemma_2.py
@@ -1,4 +1,4 @@
-"""Gemma-2 2B (Google, 2024) as a decoder-LLM classifier. Decoder-LLM-as-classifier is the dominant 2024-2025 pattern for hard classification tasks. LoRA-only fine-tune so federated averaging only syncs the adapter + classification head.
+"""Gemma-2 2B (Google, 2024) as a decoder-LLM classifier. Decoder-LLM-as-classifier is the dominant 2024-2025 pattern for hard classification tasks. Select LoRA-only fine-tuning in the training plan so federated averaging only syncs the adapter + classification head.
 
 Requirements:
 - HuggingFace token required. ``google/gemma-2-2b`` is a gated repo —
@@ -8,9 +8,11 @@ Requirements:
 - Resources: ~5GB download, ~10GB RAM for fp32 load. ~32GB system RAM
   recommended for the local SDK self-check (CPU forward+backward on
   synthetic data, expect 2-5 minutes on a laptop).
-- Trainable params (LoRA + score head): ~10M. Base ~2.5B stays frozen.
+- Params: ~2.5B (full base). Choose LoRA in the training plan to train
+  only a ~10M adapter + score head.
 """
-from peft import LoraConfig, TaskType, get_peft_model
+import os
+
 from transformers import AutoModelForSequenceClassification
 
 model_id = "google/gemma-2-2b"
@@ -25,13 +27,7 @@ output_classes = 5
 
 
 def MyModel(num_classes=output_classes):
-    base = AutoModelForSequenceClassification.from_pretrained(
-        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    return AutoModelForSequenceClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True,
+        token=os.environ.get("HF_TOKEN"),
     )
-    lora_config = LoraConfig(
-        task_type=TaskType.SEQ_CLS,
-        r=16, lora_alpha=32, lora_dropout=0.05, bias="none",
-        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
-        modules_to_save=["score"],
-    )
-    return get_peft_model(base, lora_config)

--- a/model_zoo/text_classification/pytorch/gte_modernbert.py
+++ b/model_zoo/text_classification/pytorch/gte_modernbert.py
@@ -1,4 +1,4 @@
-"""GTE-ModernBERT (Alibaba-NLP, 2025). ModernBERT fine-tuned for general text embeddings — top MTEB scores at its size; doubles as a strong classifier via mean-pool + linear head. LoRA-only fine-tune for federated averaging.
+"""GTE-ModernBERT (Alibaba-NLP, 2025). ModernBERT fine-tuned for general text embeddings — top MTEB scores at its size; doubles as a strong classifier via mean-pool + linear head. Select LoRA-only fine-tuning in the training plan for federated averaging.
 
 Requirements:
 - HuggingFace token NOT required (ungated), but recommended to avoid
@@ -11,9 +11,9 @@ Requirements:
   enough for the local SDK self-check. At ``sequence_length=512,
   batch_size=4`` expect ~1 minute on CPU; if it looks stuck on a
   bigger seq/batch, halve both.
-- Trainable params (LoRA r=8 + classifier head): ~1M. Base ~150M frozen.
+- Params: ~150M (full base). Choose LoRA in the training plan to train
+  only a ~1M adapter + classifier head.
 """
-from peft import LoraConfig, TaskType, get_peft_model
 from transformers import AutoModelForSequenceClassification
 
 model_id = "Alibaba-NLP/gte-modernbert-base"
@@ -28,13 +28,6 @@ output_classes = 5
 
 
 def MyModel(num_classes=output_classes):
-    base = AutoModelForSequenceClassification.from_pretrained(
+    return AutoModelForSequenceClassification.from_pretrained(
         model_id, num_labels=num_classes, trust_remote_code=True, ignore_mismatched_sizes=True
     )
-    lora_config = LoraConfig(
-        task_type=TaskType.SEQ_CLS,
-        r=8, lora_alpha=16, lora_dropout=0.1, bias="none",
-        target_modules=["Wqkv"],
-        modules_to_save=["classifier", "head"],
-    )
-    return get_peft_model(base, lora_config)

--- a/model_zoo/text_classification/pytorch/modernbert.py
+++ b/model_zoo/text_classification/pytorch/modernbert.py
@@ -1,5 +1,4 @@
-"""ModernBERT (Answer.AI / LightOn, Dec 2024). Drop-in BERT replacement — 8192-token context, ~3x training speed, strong on classification + retrieval. Fine-tuned LoRA-only so federated averaging only syncs the small adapter tensors."""
-from peft import LoraConfig, TaskType, get_peft_model
+"""ModernBERT (Answer.AI / LightOn, Dec 2024). Drop-in BERT replacement — 8192-token context, ~3x training speed, strong on classification + retrieval. Select LoRA-only fine-tuning in the training plan if you want federated averaging to sync only the adapter tensors."""
 from transformers import AutoModelForSequenceClassification
 
 model_id = "answerdotai/ModernBERT-base"
@@ -14,16 +13,6 @@ output_classes = 5
 
 
 def MyModel(num_classes=output_classes):
-    base = AutoModelForSequenceClassification.from_pretrained(
+    return AutoModelForSequenceClassification.from_pretrained(
         model_id, num_labels=num_classes, ignore_mismatched_sizes=True
     )
-    lora_config = LoraConfig(
-        task_type=TaskType.SEQ_CLS,
-        r=8,
-        lora_alpha=16,
-        lora_dropout=0.1,
-        bias="none",
-        target_modules=["Wqkv"],
-        modules_to_save=["classifier", "head"],
-    )
-    return get_peft_model(base, lora_config)

--- a/model_zoo/text_classification/pytorch/phi_3_mini.py
+++ b/model_zoo/text_classification/pytorch/phi_3_mini.py
@@ -1,4 +1,4 @@
-"""Phi-3-mini (Microsoft, 2024). 3.8B-param decoder LLM repurposed as a classifier — competitive with Llama-3-8B on reasoning benchmarks at half the size, and ungated on HuggingFace. LoRA-only fine-tune so federated averaging only syncs the adapter + classification head.
+"""Phi-3-mini (Microsoft, 2024). 3.8B-param decoder LLM repurposed as a classifier — competitive with Llama-3-8B on reasoning benchmarks at half the size, and ungated on HuggingFace. Select LoRA-only fine-tuning in the training plan so federated averaging only syncs the adapter + classification head.
 
 Requirements:
 - HuggingFace token NOT strictly required (model is ungated), but a
@@ -12,9 +12,9 @@ Requirements:
   forward+backward on synthetic data takes 5-15 minutes on a laptop
   even at ``batch_size=2, sequence_length=1024``. Bump
   ``sequence_length`` down to 256 if the self-check looks stuck.
-- Trainable params (LoRA r=16 + score head): ~15M. Base ~3.8B frozen.
+- Params: ~3.8B (full base). Choose LoRA in the training plan to train
+  only a ~15M adapter + score head.
 """
-from peft import LoraConfig, TaskType, get_peft_model
 from transformers import AutoModelForSequenceClassification
 
 model_id = "microsoft/Phi-3-mini-4k-instruct"
@@ -30,16 +30,9 @@ output_classes = 5
 
 
 def MyModel(num_classes=output_classes):
-    base = AutoModelForSequenceClassification.from_pretrained(
+    return AutoModelForSequenceClassification.from_pretrained(
         model_id,
         num_labels=num_classes,
         trust_remote_code=True,
         ignore_mismatched_sizes=True,
     )
-    lora_config = LoraConfig(
-        task_type=TaskType.SEQ_CLS,
-        r=16, lora_alpha=32, lora_dropout=0.05, bias="none",
-        target_modules=["qkv_proj", "o_proj"],
-        modules_to_save=["score"],
-    )
-    return get_peft_model(base, lora_config)


### PR DESCRIPTION
## What
Removes the in-file `peft`/LoRA wrapping from 5 text-classification model templates, returning the plain `AutoModelForSequenceClassification` instead: `gemma_2`, `electra`, `modernbert`, `gte_modernbert`, `phi_3_mini`.

## Why
LoRA / PEFT is now configured by the user in the **training plan**, not the model file. The `tracebloc_package` SDK enforces this with a check that rejects any model that declares PEFT from the model file itself — so the in-file `get_peft_model` wrappers would now fail validation on upload.

## Changes per file
- Drop `from peft import LoraConfig, TaskType, get_peft_model`.
- `MyModel()` now returns the bare `from_pretrained(...)` model (no `LoraConfig`, no `get_peft_model`).
- Docstrings reworded: "fine-tuned LoRA-only" → "select LoRA-only fine-tuning in the training plan"; trainable-param notes updated to "full base; choose LoRA in the training plan to train only the adapter + head".
- `gemma_2.py` also keeps the earlier fix: reads the HF token from the `HF_TOKEN` env var via the correct `token=` kwarg (was a leaked hardcoded token).

## Not included
`sapiens.py` and `timesfm.py` also carry in-file LoRA wrappers but were intentionally **left as-is** for this PR (reverted on request). They would fail the same package check and likely need a follow-up.

## Testing
All 5 files `python -m py_compile` clean. No behavioral change beyond removing the adapter wrapper — the returned base model is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upload/training behavior shifts from adapter-wrapped models to full pretrained classifiers unless users enable LoRA in the plan; Gemma-2 now depends on HF_TOKEN for gated Hub access.
> 
> **Overview**
> Removes in-file **PEFT/LoRA** wrapping from five PyTorch text-classification zoo templates (`electra`, `modernbert`, `gemma_2`, `gte_modernbert`, `phi_3_mini`). **`MyModel()`** now returns only **`AutoModelForSequenceClassification.from_pretrained(...)`** so LoRA is configured in the **training plan**, matching SDK validation that rejects PEFT declared in the model file.
> 
> Docstrings are updated to tell users to choose LoRA in the plan instead of implying the template is already adapter-only. **`gemma_2.py`** also passes the Hub token via **`HF_TOKEN`** and the **`token=`** kwarg on load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395a959f697d0674f4cb631fc9cc32e4d5ef072e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->