### PR TITLE
fix: mask2former — return semantic-seg logits instead of HF output object

### DIFF
--- a/model_zoo/semantic_segmentation/pytorch/mask2former.py
+++ b/model_zoo/semantic_segmentation/pytorch/mask2former.py
@@ -1,8 +1,33 @@
-"""Mask2Former (Meta, CVPR 2022). Dominant universal segmentation architecture — same model handles semantic / instance / panoptic via masked attention; ~57 mIoU ADE20K at Swin-L."""
-from transformers import Mask2FormerForUniversalSegmentation, Mask2FormerConfig
+"""Mask2Former (Meta, CVPR 2022). Dominant universal segmentation architecture —
+same model handles semantic / instance / panoptic via masked attention; ~57 mIoU
+ADE20K at Swin-L.
 
+This wrapper exposes the HF `Mask2FormerForUniversalSegmentation` as a plain
+semantic-segmentation module: `forward(x)` returns `[B, num_classes, H, W]`
+logits, matching the contract used by the other models in this folder
+(deeplab.py, fcn.py, ...). The platform trainer then applies its standard
+per-pixel CrossEntropyLoss against the `[B, H, W]` mask targets.
+
+We do NOT use Mask2Former's internal MaskFormerLoss here because the platform
+trainer does not pass `mask_labels` / `class_labels`; instead we derive
+semantic logits from the (mask_queries, class_queries) outputs via the standard
+collapse:
+
+    seg_logits = einsum("bqc,bqhw->bchw",
+                        softmax(class_logits)[..., :-1],
+                        sigmoid(mask_logits))
+
+then upsample to the input resolution. This is the same formula HF's
+`image_processor.post_process_semantic_segmentation` uses.
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import Mask2FormerConfig, Mask2FormerForUniversalSegmentation
+
+# Module-level metadata contract
 framework = "pytorch"
-main_method = "MyModel"
+main_class = "Mask2Former"
 license = "Apache-2.0"
 image_size = 384
 batch_size = 4
@@ -12,8 +37,39 @@ category = "semantic_segmentation"
 _PRETRAINED_ID = "facebook/mask2former-swin-tiny-ade-semantic"
 
 
-def MyModel(num_classes=output_classes):
-    config = Mask2FormerConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
-    return Mask2FormerForUniversalSegmentation.from_pretrained(
-        _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
-    )
+class Mask2Former(nn.Module):
+    def __init__(self, num_classes: int = output_classes, img_size: int = image_size):
+        super().__init__()
+        self.num_classes = num_classes
+        self.img_size = img_size
+
+        config = Mask2FormerConfig.from_pretrained(_PRETRAINED_ID, num_labels=num_classes)
+        self.model = Mask2FormerForUniversalSegmentation.from_pretrained(
+            _PRETRAINED_ID, config=config, ignore_mismatched_sizes=True
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # We bypass the HF loss path by only passing pixel_values; this returns
+        # masks_queries_logits [B, Q, H', W'] and class_queries_logits
+        # [B, Q, num_classes + 1] (last channel is the "no object" class).
+        outputs = self.model(pixel_values=x)
+
+        mask_logits = outputs.masks_queries_logits          # [B, Q, H', W']
+        class_logits = outputs.class_queries_logits          # [B, Q, C+1]
+
+        # Drop the "no object" class and collapse queries into per-class
+        # pixel logits.
+        class_probs = class_logits.softmax(dim=-1)[..., :-1]  # [B, Q, C]
+        mask_probs = mask_logits.sigmoid()                    # [B, Q, H', W']
+
+        seg_logits = torch.einsum("bqc,bqhw->bchw", class_probs, mask_probs)
+
+        # Upsample to the input spatial size so the per-pixel CE loss against
+        # [B, H, W] targets lines up.
+        seg_logits = F.interpolate(
+            seg_logits,
+            size=(self.img_size, self.img_size),
+            mode="bilinear",
+            align_corners=False,
+        )
+        return seg_logits


### PR DESCRIPTION
## Summary
- `mask2former.py` previously returned the raw HF `Mask2FormerForUniversalSegmentation`, which crashed during `model_func_checks` with `Expected target size [4, 3], got [4, 384, 384]` — the HF model expects `mask_labels`/`class_labels` kwargs that the platform trainer does not pass.
- Wrap the HF model in an `nn.Module` whose `forward(x)` returns `[B, num_classes, H, W]` logits (same contract as `deeplab.py` / `fcn.py`) by collapsing the mask/class queries the standard way and upsampling to input resolution. This is the same formula HF's `post_process_semantic_segmentation` uses.
- Also switches metadata from `main_method` to `main_class`.

## Test plan
- [x] Uploaded via SDK on staging — `model_func_checks` passes
- [x] `link_model_dataset` against `direditk` succeeds ("Assignment successful!")
- [x] Experiment is creatable end-to-end (only blocker left is unrelated FLOPS quota: `403 Forbidden: You don't have enough FLOPS to start the experiment`)
- [ ] Reviewer: run a real training cycle once FLOPS quota is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single model-zoo wrapper change; aligns I/O with other segmentation models and avoids HF-specific label kwargs.
> 
> **Overview**
> **Mask2Former** in the semantic-segmentation model zoo no longer exposes the raw Hugging Face universal-segmentation model. It is wrapped in an `nn.Module` whose `forward` returns **`[B, num_classes, H, W]`** logits so the platform trainer can use the same per-pixel cross-entropy path as **DeepLab** / **FCN**, instead of failing checks when targets are **`[B, H, W]`** masks.
> 
> Logits are built by collapsing mask and class query outputs (softmax over classes minus the no-object slot, sigmoid on masks, einsum), then **bilinear upsampling** to the configured input size—matching HF’s semantic post-processing, without **`mask_labels` / `class_labels`**. Metadata switches from **`main_method`** / **`MyModel`** to **`main_class`** **`Mask2Former`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dcff2845f9b0c24f429ceb4c3bf2d5314ba6b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->