### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,18 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# tracebloc-py-package upload artifacts — the SDK extracts each uploaded
+# model into a ``tmpmodel_<name>/`` sibling directory and (usually) cleans
+# it up on success; failed uploads leave the dir behind. Ignoring them
+# project-wide keeps stale extractions from being picked up by recursive
+# model walkers (e.g. local experiment runners) and from accidentally
+# being committed.
+tmpmodel_*/
+
+# Local experiment driver scripts often carry hard-coded credentials
+# during dev. Keep them out of the repo.
+experiments/
+
 #pycharm
 *.idea/
 

--- a/model_zoo/keypoint_detection/pytorch/sapiens.py
+++ b/model_zoo/keypoint_detection/pytorch/sapiens.py
@@ -1,4 +1,28 @@
-"""Sapiens (Meta, ECCV 2024). Human-centric foundation model — pose, depth, normals, segmentation in one family. The official `facebook/sapiens-pose-*` Hub repos ship as TorchScript artifacts (not loadable via AutoModel), so this template loads the MAE-pretrained ViT backbone `facebook/sapiens-pretrain-0.3b` and attaches a fresh pose head. Fine-tuned LoRA-only so federated averaging only syncs the adapter + final regressor."""
+"""Sapiens (Meta, ECCV 2024). Human-centric foundation model — pose, depth,
+normals, segmentation in one family.
+
+Backbone-loading note
+---------------------
+The official ``facebook/sapiens-pose-*`` Hub repos ship as TorchScript
+artifacts (not loadable via ``AutoModel``), and the MAE-pretrained
+``facebook/sapiens-pretrain-0.3b`` repo ships a ``config.json`` that
+lacks a ``model_type`` key — so ``AutoModel.from_pretrained`` rejects
+it during ``model_func_checks`` with:
+
+    Unrecognized model in facebook/sapiens-pretrain-0.3b. Should have a
+    `model_type` key in its config.json.
+
+even with ``trust_remote_code=True`` (the repo doesn't ship a custom
+modeling file either). Until Meta publishes an HF-AutoModel-loadable
+sapiens checkpoint, we substitute the upstream ViT-MAE base backbone
+sapiens is architecturally built on (``facebook/vit-mae-base``). The
+ViT geometry matches; only the human-centric pretraining is lost.
+Switch ``_BACKBONE_ID`` back to ``facebook/sapiens-pretrain-0.3b`` once
+that repo's config carries ``model_type: vit_mae``.
+
+Fine-tuned LoRA-only so federated averaging only syncs the adapter +
+the final regressor.
+"""
 import torch.nn as nn
 from peft import LoraConfig, get_peft_model
 from transformers import AutoModel
@@ -13,7 +37,7 @@ output_classes = 1
 category = "keypoint_detection"
 num_feature_points = 17
 
-_BACKBONE_ID = "facebook/sapiens-pretrain-0.3b"
+_BACKBONE_ID = "facebook/vit-mae-base"
 
 
 class _SapiensWrapper(nn.Module):
@@ -33,10 +57,23 @@ class _SapiensWrapper(nn.Module):
 
 
 def MyModel(num_feature_points=num_feature_points):
-    base = AutoModel.from_pretrained(_BACKBONE_ID, trust_remote_code=True)
+    # ViT-MAE base ships at 224x224 by default; we declare 256 above to
+    # match the rest of the keypoint model family. ``image_size`` is a
+    # config-level override (the position embeddings get interpolated to
+    # fit), and ``ignore_mismatched_sizes=True`` is required because the
+    # checkpoint's position-embedding tensor stays at the 224-grid shape
+    # — HF reinitializes those positions rather than raising. The patch
+    # projection and attention weights still load.
+    base = AutoModel.from_pretrained(
+        _BACKBONE_ID, image_size=image_size, ignore_mismatched_sizes=True,
+    )
     lora_config = LoraConfig(
         r=8, lora_alpha=16, lora_dropout=0.1, bias="none",
-        target_modules=["qkv", "proj"],
+        # ViT-MAE exposes attention as ``query`` / ``key`` / ``value`` /
+        # ``output.dense`` (not the fused ``qkv`` block used by some ViT
+        # variants), so the LoRA target list has to match that naming
+        # for the adapter wrap to land.
+        target_modules=["query", "value"],
     )
     base = get_peft_model(base, lora_config)
     return _SapiensWrapper(base, num_feature_points)

--- a/model_zoo/keypoint_detection/pytorch/vitpose_plus.py
+++ b/model_zoo/keypoint_detection/pytorch/vitpose_plus.py
@@ -20,18 +20,51 @@ class _Wrapper(nn.Module):
     def __init__(self, model):
         super().__init__()
         self.model = model
+        # ViTPose++ ships a Mixture-of-Experts head with one expert per
+        # training dataset (COCO / AIC / MPII / …).
+        # ``VitPoseForPoseEstimation.forward`` therefore requires a
+        # ``dataset_index`` kwarg on every call to pick which expert
+        # routes the features — without it, ``model_func_checks`` rejects
+        # the file with:
+        #
+        #     dataset_index must be provided when using multiple experts
+        #     (num_experts=6). Please provide dataset_index to the
+        #     forward pass.
+        #
+        # We always select expert 0 because the platform's keypoint
+        # pipeline is a single-dataset fine-tune — there's no per-batch
+        # routing decision to make.
+        self._expert_index = 0
 
     def forward(self, pixel_values, *args, **kwargs):
-        heatmaps = self.model(pixel_values=pixel_values).heatmaps
+        batch, _, in_h, in_w = pixel_values.shape
+        dataset_index = torch.full(
+            (batch,),
+            self._expert_index,
+            dtype=torch.long,
+            device=pixel_values.device,
+        )
+        heatmaps = self.model(
+            pixel_values=pixel_values, dataset_index=dataset_index
+        ).heatmaps
         b, k, h, w = heatmaps.shape
         flat = heatmaps.view(b, k, -1)
         probs = torch.softmax(flat, dim=-1)
-        ys = torch.linspace(0, 1, h, device=heatmaps.device).view(1, 1, h, 1)
-        xs = torch.linspace(0, 1, w, device=heatmaps.device).view(1, 1, 1, w)
+        # Soft-argmax in *pixel* space. The platform's keypoint targets
+        # are pixel coordinates in the input image; emitting normalized
+        # ``[0, 1]`` coords here would scale the per-pixel MSE loss by
+        # ``image_size ** 2`` and explode gradients — we observed loss
+        # ~1e11 with ``val_loss = NaN`` on the first cycle before this
+        # change.
+        ys = torch.linspace(0, in_h - 1, h, device=heatmaps.device).view(1, 1, h, 1)
+        xs = torch.linspace(0, in_w - 1, w, device=heatmaps.device).view(1, 1, 1, w)
         probs2d = probs.view(b, k, h, w)
         x_coord = (probs2d * xs).sum(dim=(2, 3))
         y_coord = (probs2d * ys).sum(dim=(2, 3))
-        conf = flat.max(dim=-1).values
+        # Confidence — squashed to ``[0, 1]`` so it can't dominate the
+        # loss against per-keypoint visibility flags. Raw ``flat.max``
+        # is an unbounded transformer logit (easily 1e2+ at init).
+        conf = torch.sigmoid(flat.max(dim=-1).values)
         return torch.stack([x_coord, y_coord, conf], dim=-1)
 
 


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect training loss scaling and pretrained weights for two keypoint zoo templates; wrong coordinate or LoRA wiring would silently hurt fine-tune quality but scope is limited to those model definitions.
> 
> **Overview**
> **`.gitignore`** now ignores SDK upload scratch dirs (`tmpmodel_*/`) and local **`experiments/`** so stale model extractions and dev scripts with credentials do not get picked up or committed.
> 
> **`sapiens.py`** switches the backbone from **`facebook/sapiens-pretrain-0.3b`** to **`facebook/vit-mae-base`** because the Sapiens Hub config is not **`AutoModel`**-loadable today. Loading passes **`image_size=256`** and **`ignore_mismatched_sizes=True`**, and LoRA **`target_modules`** change from **`qkv`/`proj`** to **`query`/`value`** for ViT-MAE naming.
> 
> **`vitpose_plus.py`** fixes MoE **`dataset_index`** (always expert 0) so **`model_func_checks`** and forward succeed. Soft-argmax now outputs **pixel** coordinates aligned with platform targets (was normalized **[0, 1]**, which blew up MSE), and confidence uses **`sigmoid`** on peak heatmap logits instead of raw max values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736b15ca988256f8aadce022df6f4e6f4fd739a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->