### PR TITLE
fix: drop unnecessary trust_remote_code (gte_modernbert, phi_3_mini, aimv2)

### DIFF
--- a/model_zoo/image_classification/pytorch/aimv2.py
+++ b/model_zoo/image_classification/pytorch/aimv2.py
@@ -16,7 +16,10 @@ _BACKBONE_ID = "apple/aimv2-large-patch14-224"
 class MyModel(nn.Module):
     def __init__(self, num_classes=output_classes):
         super().__init__()
-        self.backbone = AutoModel.from_pretrained(_BACKBONE_ID, trust_remote_code=True)
+        # Native Aimv2VisionModel (config model_type="aimv2_vision_model") —
+        # no trust_remote_code, so it passes the platform security check
+        # and avoids the custom-code path's all_tied_weights_keys bug.
+        self.backbone = AutoModel.from_pretrained(_BACKBONE_ID)
         for p in self.backbone.parameters():
             p.requires_grad = False
         hidden = self.backbone.config.hidden_size

--- a/model_zoo/text_classification/pytorch/gte_modernbert.py
+++ b/model_zoo/text_classification/pytorch/gte_modernbert.py
@@ -4,9 +4,10 @@ Requirements:
 - HuggingFace token NOT required (ungated), but recommended to avoid
   Hub rate-limits. If you set one, read it from env — never commit a
   token to this file.
-- ``trust_remote_code=True`` is required — gte-modernbert ships custom
-  modeling code. First load downloads the remote code; on slow networks
-  this step alone can take a minute.
+- No ``trust_remote_code`` needed — gte-modernbert's config declares
+  ``model_type="modernbert"``, which transformers (>=4.48) loads with
+  the **native** ``ModernBertForSequenceClassification`` class. Avoiding
+  remote code is required to pass the platform's model-security check.
 - Resources: ~600MB download, ~2GB RAM for load. ~8GB system RAM is
   enough for the local SDK self-check. At ``sequence_length=512,
   batch_size=4`` expect ~1 minute on CPU; if it looks stuck on a
@@ -29,5 +30,5 @@ output_classes = 5
 
 def MyModel(num_classes=output_classes):
     return AutoModelForSequenceClassification.from_pretrained(
-        model_id, num_labels=num_classes, trust_remote_code=True, ignore_mismatched_sizes=True
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
     )

--- a/model_zoo/text_classification/pytorch/phi_3_mini.py
+++ b/model_zoo/text_classification/pytorch/phi_3_mini.py
@@ -5,8 +5,10 @@ Requirements:
   token avoids HF Hub rate-limits on cold pulls. If you set one, read
   it from env — DO NOT commit a token to this file; uploaded files
   leak any secret embedded in them.
-- ``trust_remote_code=True`` is required — Phi-3 ships custom modeling
-  code that HF downloads on first load.
+- No ``trust_remote_code`` needed — Phi-3's config declares
+  ``model_type="phi3"``, which transformers loads with the native
+  ``Phi3ForSequenceClassification`` class. Avoiding remote code is
+  required to pass the platform's model-security check.
 - Resources: ~8GB download (fp32), ~16GB RAM for load. ~32GB system
   RAM strongly recommended for the local SDK self-check; the CPU
   forward+backward on synthetic data takes 5-15 minutes on a laptop
@@ -33,6 +35,5 @@ def MyModel(num_classes=output_classes):
     return AutoModelForSequenceClassification.from_pretrained(
         model_id,
         num_labels=num_classes,
-        trust_remote_code=True,
         ignore_mismatched_sizes=True,
     )


### PR DESCRIPTION
## Problem
The platform's model-security check rejects `from_pretrained(..., trust_remote_code=True)` unless the source repo is on the vetted-repos allowlist. Three zoo models set this flag unnecessarily, so they failed upload with *"Model is insecure … trust_remote_code is forbidden …"* even though the model itself is fine.

## Fix
Each of these declares a `model_type` that **transformers (>=4.48) supports natively**, so `trust_remote_code` was unnecessary. Removing it loads the same architecture via the native class and passes the security check:

| Model | model_type | Native class |
|---|---|---|
| `gte_modernbert` | `modernbert` | `ModernBertForSequenceClassification` |
| `phi_3_mini` | `phi3` | `Phi3ForSequenceClassification` |
| `aimv2` | `aimv2_vision_model` | `Aimv2VisionModel` |

**Bonus for `aimv2`:** the native class also avoids the `all_tied_weights_keys` error the custom remote-code path hit on transformers 5.x — so aimv2 goes from "fails validation" to "uploads".

## Verification
- Confirmed each loads natively without `trust_remote_code`.
- `gte_modernbert` and `aimv2` verified **end-to-end** — uploaded and experiments created on staging.
- `phi_3_mini` edit verified at the config/class level (native `Phi3ForSequenceClassification` resolves); a full 3.8B upload self-check needs a >16 GB-RAM host.

## Left unchanged
- `sapiens` genuinely requires remote code (its config has no recognized `model_type`, so `AutoConfig` can't load it natively) — intentionally not touched.
- `timesfm` was already fixed on `master` (now uses `TimesFmModelForPrediction`, no remote code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to HuggingFace load flags and comments in model zoo stubs; intended to preserve architecture while satisfying security checks.
> 
> **Overview**
> Removes **`trust_remote_code=True`** from three model zoo loaders so uploads pass the platform model-security check, which forbids remote code unless the Hub repo is allowlisted.
> 
> **`aimv2`**, **`gte_modernbert`**, and **`phi_3_mini`** now rely on native Transformers classes (`aimv2_vision_model`, `modernbert`, `phi3`) via `AutoModel` / `AutoModelForSequenceClassification` without the flag. Docstrings are updated to say remote code is not required and that avoiding it is required for the security check. For **aimv2**, inline comments note this also sidesteps a custom-code **`all_tied_weights_keys`** issue on Transformers 5.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d41ed0b4a6549bf677be20dcb9c63f039890b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->