### PR TITLE
fix(mlm): make netmedgpt_style_warmstart loadable (class entrypoint + vocab)

### DIFF
--- a/model_zoo/masked_language_modeling/pytorch/netmedgpt_style_warmstart.py
+++ b/model_zoo/masked_language_modeling/pytorch/netmedgpt_style_warmstart.py
@@ -1,36 +1,51 @@
-"""BERT-base warm-started from HuggingFace pretrained weights, adapted for MLM on custom vocab. Fine-tune on domain corpora."""
+"""BERT-base warm-started from HuggingFace pretrained weights, adapted for MLM. Fine-tune on domain corpora."""
+import torch.nn as nn
 from transformers import AutoConfig, AutoModelForMaskedLM
 
 framework = "pytorch"
-main_method = "NetMedGPTWarmStart"
+main_class = "NetMedGPTWarmStart"
 category = "masked_language_modeling"
 model_type = ""
 batch_size = 16
 sequence_length = 128
-vocab_size = 30000
+# Must match the bert-base-uncased tokenizer's vocab (30522). The previous
+# value (30000) shrank the embedding table below the tokenizer, so token ids
+# 30000-30521 caused CUDA index-out-of-bounds at training time.
+vocab_size = 30522
 
 # HuggingFace model to warm-start from
 pretrained_model_id = "bert-base-uncased"
 
 
-def NetMedGPTWarmStart(vocab_size=vocab_size):
-    """Load BERT-base-uncased and resize embeddings for a custom vocabulary.
+class NetMedGPTWarmStart(nn.Module):
+    """BERT-base-uncased warm-started from pretrained weights for MLM.
 
     Warm-starting from general-domain pretrained weights accelerates
     convergence on biomedical corpora compared to training from scratch.
-    The embedding layer and LM head are resized to match the custom
-    tokenizer's vocabulary — new token embeddings are randomly initialized
-    while existing ones retain their pretrained values.
+    The embedding layer and LM head are resized to the configured vocab —
+    new token embeddings are randomly initialized while existing ones
+    retain their pretrained values.
 
-    Returns an ``AutoModelForMaskedLM`` instance whose ``.forward()``
-    accepts ``input_ids``, ``attention_mask``, and ``labels``, returning
-    a ``MaskedLMOutput`` with ``.loss`` and ``.logits``.
+    ``forward`` accepts ``input_ids``, ``attention_mask`` and ``labels``
+    and returns a ``MaskedLMOutput`` with ``.loss`` and ``.logits``.
+
+    Authored as an ``nn.Module`` subclass (``main_class``) rather than a
+    factory function (``main_method``): the platform's model loader resolves
+    the class entrypoint reliably, whereas the factory-function form failed
+    to load server-side.
     """
-    config = AutoConfig.from_pretrained(pretrained_model_id)
-    model = AutoModelForMaskedLM.from_pretrained(
-        pretrained_model_id,
-        config=config,
-        ignore_mismatched_sizes=True,
-    )
-    model.resize_token_embeddings(vocab_size)
-    return model
+
+    def __init__(self, vocab_size=vocab_size):
+        super(NetMedGPTWarmStart, self).__init__()
+        config = AutoConfig.from_pretrained(pretrained_model_id)
+        self.model = AutoModelForMaskedLM.from_pretrained(
+            pretrained_model_id,
+            config=config,
+            ignore_mismatched_sizes=True,
+        )
+        self.model.resize_token_embeddings(vocab_size)
+
+    def forward(self, input_ids, attention_mask=None, labels=None, **kwargs):
+        return self.model(
+            input_ids=input_ids, attention_mask=attention_mask, labels=labels
+        )


### PR DESCRIPTION
## Problem

`netmedgpt_style_warmstart` could not train. Investigating on **dev** surfaced **two independent defects**:

1. **Entrypoint form.** It was the only MLM model declared as a `main_method` factory function. The platform's server-side model loader fails to resolve factory-function entrypoints — upload is rejected with `Error loading the model file … has no attribute 'MyModel'` — while every `main_class` (nn.Module subclass) model loads fine.
2. **Vocab mismatch.** `vocab_size = 30000` shrank the embedding table below the `bert-base-uncased` tokenizer (30522). Token ids 30000–30521 would hit a CUDA index-out-of-bounds at training time; the client now fail-fasts on this mismatch (tracebloc-client #360).

## Fix

- Rewrite the model as an `nn.Module` subclass (`main_class = "NetMedGPTWarmStart"`) instead of a factory function — same warm-start behavior (`from_pretrained` + `resize_token_embeddings`).
- Set `vocab_size = 30522` to match the tokenizer.

## Verification

Both forms tested against dev (dataset `dwjdk2dm`):

| variant | entrypoint | vocab | result |
|---|---|---|---|
| original | `main_method` fn | 30000 | rejected (vocab guard) |
| fixed-vocab only | `main_method` fn | 30522 | rejected (`no attribute 'MyModel'`) |
| **this PR** | **`main_class`** | **30522** | ✅ uploads + experiment starts (`eemgcqxq`) |

An offline class-vs-function control pair (identical model, only the entrypoint form differs) isolated the loader defect: the class form starts, the function form fails — independent of vocab and of HuggingFace.

## Follow-up (separate, platform-side)

The `main_method` factory-function entrypoint failing server-side load is a platform bug — the metadata contract advertises both `main_class` and `main_method`. Worth a fix in the model loader so factory-function models work too. This PR only unblocks the zoo model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated model-zoo definition change; aligns entrypoint and vocab with sibling MLM models without touching platform auth or data paths.
> 
> **Overview**
> **`netmedgpt_style_warmstart`** is updated so it can upload and train on the platform: the entrypoint switches from a **`main_method`** factory to a **`main_class`** **`nn.Module`** subclass (matching other MLM zoo models), with **`forward`** delegating to the same HuggingFace **`AutoModelForMaskedLM`** warm-start path.
> 
> **`vocab_size`** is raised from **30000** to **30522** so embeddings match **`bert-base-uncased`** and token ids no longer index past the embedding table at training time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d31380c32e9ec2ab540d28f41b2340e49eba18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->