### PR TITLE
Develop to prod

### DIFF
--- a/.github/workflows/fr-gate-caller.yml
+++ b/.github/workflows/fr-gate-caller.yml
@@ -1,0 +1,15 @@
+name: FR gate
+
+# Per-repo caller. Blocks merges to staging/main/master unless every contained
+# kanban item is in "Ready for staging" or "Ready for prod" respectively.
+# All logic lives in tracebloc/.github/.github/workflows/fr-gate.yml.
+
+on:
+  pull_request:
+    branches: [staging, main, master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+jobs:
+  gate:
+    uses: tracebloc/.github/.github/workflows/fr-gate.yml@main
+    secrets: inherit

--- a/model_zoo/image_classification/pytorch/aimv2.py
+++ b/model_zoo/image_classification/pytorch/aimv2.py
@@ -16,7 +16,10 @@ _BACKBONE_ID = "apple/aimv2-large-patch14-224"
 class MyModel(nn.Module):
     def __init__(self, num_classes=output_classes):
         super().__init__()
-        self.backbone = AutoModel.from_pretrained(_BACKBONE_ID, trust_remote_code=True)
+        # Native Aimv2VisionModel (config model_type="aimv2_vision_model") —
+        # no trust_remote_code, so it passes the platform security check
+        # and avoids the custom-code path's all_tied_weights_keys bug.
+        self.backbone = AutoModel.from_pretrained(_BACKBONE_ID)
         for p in self.backbone.parameters():
             p.requires_grad = False
         hidden = self.backbone.config.hidden_size

--- a/model_zoo/tabular_classification/README.md
+++ b/model_zoo/tabular_classification/README.md
@@ -16,6 +16,29 @@ Classify structured, tabular records into discrete categories.
 | [`lightgbm_classifier.py`](sklearn/lightgbm_classifier.py) | Faster training than XGBoost, often near-tied accuracy |
 | [`catboost_classifier.py`](sklearn/catboost_classifier.py) | Best handling of categorical features with minimal preprocessing |
 
+### sklearn — feature stability selection
+
+For biomarker-panel / feature-selection studies: these models run repeated stratified
+cross-validation **inside** `fit` and report how often each feature is selected, plus
+held-out AUROC per fold.
+
+| Model | When to pick |
+|---|---|
+| [`logistic_regression_stability.py`](sklearn/logistic_regression_stability.py) | LASSO (L1) selection frequency + signed direction of effect |
+| [`random_forest_stability.py`](sklearn/random_forest_stability.py) | Random-forest importance-based selection; consensus comparator to LASSO |
+
+From the platform's point of view both are ordinary sklearn classifiers
+(`fit` / `predict` / `predict_proba`), so they upload and train through the normal
+tracebloc flow with **no special configuration**. Internally `fit` runs
+`n_splits` × `n_repeats` CV (default 10 × 10 = 100 models), building a fresh
+`impute → scale → estimator` pipeline per fold so per-fold statistics never leak
+across the split. Class imbalance is handled with `class_weight='balanced'`.
+
+Run the experiment with **1 epoch, 1 cycle** — the resampling happens inside a single
+`fit`; extra epochs just repeat the whole CV. Defaults assume binary classification
+(`output_classes = 2`) with ~12 features (`num_feature_points = 12`); edit those
+module-level values to match your dataset before uploading.
+
 ### PyTorch (pick when features have sequential/spatial structure)
 
 | Model | When to pick |
@@ -34,3 +57,39 @@ Same architectures as PyTorch, under [`tensorflow/`](tensorflow/). Pick the fram
 - **Input**: tabular rows with `num_feature_points` numeric features.
 - **Labels**: integer class IDs.
 - **Batch size**: default 4096 (PyTorch/TF), 512 (sklearn).
+
+## Reading stability-selection results
+
+The two `*_stability.py` models save the fitted estimator as the experiment's weights
+artifact, carrying the selection results as attributes. Download the artifact and call
+`get_stability_report()`. Because the artifact stores a custom class, point the loader at
+the model file so the class resolves (the shim below works regardless of the artifact's
+internal module name):
+
+```python
+import pickle, importlib.util
+
+# 1) make the model class importable
+spec = importlib.util.spec_from_file_location("stab", "logistic_regression_stability.py")
+stab = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(stab)
+
+class _Loader(pickle.Unpickler):
+    def find_class(self, module, name):
+        if name == "StabilityFeatureSelector":
+            return stab.StabilityFeatureSelector
+        return super().find_class(module, name)
+
+# 2) load the downloaded weights artifact
+with open("trained_weights.pkl", "rb") as f:
+    model = _Loader(f).load()
+
+report = model.get_stability_report()
+#   report["features"]   per-feature: selection_frequency, mean_effect, direction (sorted)
+#   report["fold_aurocs"]  held-out AUROC for every fold
+#   report["summary"]      auroc_mean / std / min / max / n_folds
+```
+
+For the LASSO model, `features[i]["direction"]` is the sign of the mean L1 coefficient
+(direction of effect). For the random-forest model, `mean_effect` is the mean importance
+magnitude and direction is not meaningful — use the LASSO model for direction.

--- a/model_zoo/tabular_classification/sklearn/logistic_regression_stability.py
+++ b/model_zoo/tabular_classification/sklearn/logistic_regression_stability.py
@@ -1,0 +1,193 @@
+"""LASSO logistic regression with stability-based feature selection.
+
+A drop-in tabular-classification model whose ``fit`` runs repeated stratified
+cross-validation and records, per fold, which features the model keeps
+(non-zero L1 coefficients) and the held-out AUROC. After fit it behaves like
+any sklearn classifier — ``predict`` / ``predict_proba`` come from a final
+model trained on all rows — while also exposing a stability report:
+
+    selection_frequency_   fraction of folds in which each feature was kept
+    mean_coefficient_      mean signed coefficient per feature (direction of effect)
+    fold_aurocs_           held-out AUROC for every fold
+
+Call ``get_stability_report()`` for a ready-to-tabulate dict. The fitted model
+is saved by the tracebloc client as the experiment's weights artifact; download
+it, load the estimator, and read these attributes to build a selection-frequency
+panel — no raw data leaves the environment.
+
+Preprocessing (median imputation + standardisation) is fit INSIDE each CV fold
+via an sklearn Pipeline, so per-fold statistics never leak across the split.
+Class imbalance is handled with ``class_weight='balanced'``.
+"""
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin, clone
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import RepeatedStratifiedKFold
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+framework = "sklearn"
+model_type = "linear"
+main_method = "MyModel"
+batch_size = 4
+output_classes = 2
+category = "tabular_classification"
+num_feature_points = 12
+license = "MIT"
+
+
+class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
+    """Repeated stratified-CV feature-stability wrapper around a base classifier.
+
+    ``fit`` runs ``n_splits`` x ``n_repeats`` cross-validation, fitting a fresh
+    ``Pipeline(impute -> scale -> base_estimator)`` per fold so imputation and
+    scaling are learned inside the fold (no leakage). It tracks how often each
+    feature is selected and its mean effect, plus per-fold held-out AUROC, then
+    trains one final pipeline on all rows for ``predict`` / ``predict_proba``.
+    """
+
+    def __init__(
+        self,
+        base_estimator=None,
+        n_splits=10,
+        n_repeats=10,
+        random_state=42,
+        importance_threshold=None,
+    ):
+        self.base_estimator = base_estimator
+        self.n_splits = n_splits
+        self.n_repeats = n_repeats
+        self.random_state = random_state
+        self.importance_threshold = importance_threshold
+
+    @staticmethod
+    def _build_pipeline(estimator):
+        return Pipeline(
+            [
+                ("imputer", SimpleImputer(strategy="median", keep_empty_features=True)),
+                ("scaler", StandardScaler()),
+                ("estimator", estimator),
+            ]
+        )
+
+    def _selection_signal(self, fitted_estimator, n_features):
+        """Return (selected_mask, signed_effect) for one fitted leaf estimator."""
+        if hasattr(fitted_estimator, "coef_"):
+            coef = np.ravel(fitted_estimator.coef_)
+            if coef.shape[0] != n_features:
+                coef = np.resize(coef, n_features)
+            return np.abs(coef) > 1e-8, coef
+        if hasattr(fitted_estimator, "feature_importances_"):
+            imp = np.asarray(fitted_estimator.feature_importances_, dtype=float)
+            threshold = (
+                self.importance_threshold
+                if self.importance_threshold is not None
+                else 1.0 / max(n_features, 1)
+            )
+            return imp > threshold, imp
+        # No coef_/feature_importances_ — permutation importance is out of scope for V1.
+        return np.zeros(n_features, dtype=bool), np.zeros(n_features)
+
+    def fit(self, X, y):
+        if self.base_estimator is None:
+            raise ValueError("StabilityFeatureSelector requires a base_estimator.")
+        X = np.asarray(X, dtype=float)
+        y = np.asarray(y).ravel()
+        n_features = X.shape[1]
+        self.n_features_in_ = n_features
+        self.classes_ = np.unique(y)
+
+        # StratifiedKFold needs n_splits <= smallest class count; degrade gracefully
+        # (e.g. the SDK's tiny dummy-data validation fit) instead of erroring.
+        _, class_counts = np.unique(y, return_counts=True)
+        min_class = int(class_counts.min()) if class_counts.size else 0
+        eff_splits = min(self.n_splits, min_class)
+
+        select_counts = np.zeros(n_features)
+        effect_sums = np.zeros(n_features)
+        fold_aurocs = []
+        n_folds = 0
+
+        if eff_splits >= 2:
+            splitter = RepeatedStratifiedKFold(
+                n_splits=eff_splits,
+                n_repeats=self.n_repeats,
+                random_state=self.random_state,
+            )
+            for train_idx, val_idx in splitter.split(X, y):
+                pipe = self._build_pipeline(clone(self.base_estimator))
+                pipe.fit(X[train_idx], y[train_idx])
+                selected, effect = self._selection_signal(
+                    pipe.named_steps["estimator"], n_features
+                )
+                select_counts += selected
+                effect_sums += effect
+                n_folds += 1
+                y_val = y[val_idx]
+                if np.unique(y_val).size >= 2 and hasattr(pipe, "predict_proba"):
+                    try:
+                        proba = pipe.predict_proba(X[val_idx])[:, 1]
+                        fold_aurocs.append(float(roc_auc_score(y_val, proba)))
+                    except Exception:
+                        pass
+
+        self.n_folds_total_ = n_folds
+        self.selection_frequency_ = (
+            select_counts / n_folds if n_folds else select_counts
+        )
+        self.mean_coefficient_ = effect_sums / n_folds if n_folds else effect_sums
+        self.fold_aurocs_ = fold_aurocs
+
+        # Final model on all rows — used for predict/predict_proba and weight export.
+        self.final_estimator_ = self._build_pipeline(
+            clone(self.base_estimator)
+        ).fit(X, y)
+        return self
+
+    def predict(self, X):
+        return self.final_estimator_.predict(np.asarray(X, dtype=float))
+
+    def predict_proba(self, X):
+        return self.final_estimator_.predict_proba(np.asarray(X, dtype=float))
+
+    def get_stability_report(self):
+        """Plain dict of the stability results, ready to tabulate or store as JSON."""
+        freq = np.asarray(getattr(self, "selection_frequency_", []))
+        eff = np.asarray(getattr(self, "mean_coefficient_", []))
+        features = [
+            {
+                "feature_index": int(i),
+                "selection_frequency": float(freq[i]),
+                "mean_effect": float(eff[i]),
+                "direction": int(np.sign(eff[i])),
+            }
+            for i in range(len(freq))
+        ]
+        features.sort(key=lambda d: d["selection_frequency"], reverse=True)
+        aurocs = [float(a) for a in getattr(self, "fold_aurocs_", [])]
+        summary = {}
+        if aurocs:
+            summary = {
+                "auroc_mean": float(np.mean(aurocs)),
+                "auroc_std": float(np.std(aurocs)),
+                "auroc_min": float(np.min(aurocs)),
+                "auroc_max": float(np.max(aurocs)),
+                "n_folds": int(getattr(self, "n_folds_total_", 0)),
+            }
+        return {"features": features, "fold_aurocs": aurocs, "summary": summary}
+
+
+def MyModel():
+    return StabilityFeatureSelector(
+        base_estimator=LogisticRegression(
+            penalty="l1",
+            solver="liblinear",
+            class_weight="balanced",
+            random_state=42,
+        ),
+        n_splits=10,
+        n_repeats=10,
+        random_state=42,
+    )

--- a/model_zoo/tabular_classification/sklearn/logistic_regression_stability.py
+++ b/model_zoo/tabular_classification/sklearn/logistic_regression_stability.py
@@ -75,10 +75,15 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
     def _selection_signal(self, fitted_estimator, n_features):
         """Return (selected_mask, signed_effect) for one fitted leaf estimator."""
         if hasattr(fitted_estimator, "coef_"):
-            coef = np.ravel(fitted_estimator.coef_)
-            if coef.shape[0] != n_features:
-                coef = np.resize(coef, n_features)
-            return np.abs(coef) > 1e-8, coef
+            coef = np.atleast_2d(np.asarray(fitted_estimator.coef_, dtype=float))
+            # Binary logreg has shape (1, n_features); multiclass has (n_classes, n_features).
+            # Use the per-feature coefficient with the largest magnitude so both
+            # the selected mask and the signed effect stay meaningful across classes.
+            if coef.shape[1] != n_features:
+                return np.zeros(n_features, dtype=bool), np.zeros(n_features)
+            argmax_class = np.argmax(np.abs(coef), axis=0)
+            signed = coef[argmax_class, np.arange(n_features)]
+            return np.abs(signed) > 1e-8, signed
         if hasattr(fitted_estimator, "feature_importances_"):
             imp = np.asarray(fitted_estimator.feature_importances_, dtype=float)
             threshold = (
@@ -110,7 +115,8 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
         fold_aurocs = []
         n_folds = 0
 
-        if eff_splits >= 2:
+        # Stratified CV needs >=2 classes overall AND enough samples per class.
+        if eff_splits >= 2 and self.classes_.size >= 2:
             splitter = RepeatedStratifiedKFold(
                 n_splits=eff_splits,
                 n_repeats=self.n_repeats,
@@ -128,8 +134,14 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
                 y_val = y[val_idx]
                 if np.unique(y_val).size >= 2 and hasattr(pipe, "predict_proba"):
                     try:
-                        proba = pipe.predict_proba(X[val_idx])[:, 1]
-                        fold_aurocs.append(float(roc_auc_score(y_val, proba)))
+                        proba = pipe.predict_proba(X[val_idx])
+                        if proba.shape[1] == 2:
+                            score = roc_auc_score(y_val, proba[:, 1])
+                        else:
+                            score = roc_auc_score(
+                                y_val, proba, multi_class="ovr", labels=self.classes_
+                            )
+                        fold_aurocs.append(float(score))
                     except Exception:
                         pass
 

--- a/model_zoo/tabular_classification/sklearn/random_forest_stability.py
+++ b/model_zoo/tabular_classification/sklearn/random_forest_stability.py
@@ -115,7 +115,8 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
         fold_aurocs = []
         n_folds = 0
 
-        if eff_splits >= 2:
+        # Stratified CV needs >=2 classes overall AND enough samples per class.
+        if eff_splits >= 2 and self.classes_.size >= 2:
             splitter = RepeatedStratifiedKFold(
                 n_splits=eff_splits,
                 n_repeats=self.n_repeats,
@@ -133,8 +134,14 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
                 y_val = y[val_idx]
                 if np.unique(y_val).size >= 2 and hasattr(pipe, "predict_proba"):
                     try:
-                        proba = pipe.predict_proba(X[val_idx])[:, 1]
-                        fold_aurocs.append(float(roc_auc_score(y_val, proba)))
+                        proba = pipe.predict_proba(X[val_idx])
+                        if proba.shape[1] == 2:
+                            score = roc_auc_score(y_val, proba[:, 1])
+                        else:
+                            score = roc_auc_score(
+                                y_val, proba, multi_class="ovr", labels=self.classes_
+                            )
+                        fold_aurocs.append(float(score))
                     except Exception:
                         pass
 

--- a/model_zoo/tabular_classification/sklearn/random_forest_stability.py
+++ b/model_zoo/tabular_classification/sklearn/random_forest_stability.py
@@ -1,0 +1,197 @@
+"""Random Forest with stability-based feature selection.
+
+A drop-in tabular-classification model whose ``fit`` runs repeated stratified
+cross-validation and records, per fold, which features the forest keeps
+(importance above 1/n_features) and the held-out AUROC. After fit it behaves
+like any sklearn classifier — ``predict`` / ``predict_proba`` come from a final
+model trained on all rows — while also exposing a stability report:
+
+    selection_frequency_   fraction of folds in which each feature was kept
+    mean_coefficient_      mean feature importance per feature (magnitude; unsigned)
+    fold_aurocs_           held-out AUROC for every fold
+
+This is the consensus comparator to the LASSO variant
+(``logistic_regression_stability.py``): tree importances are non-negative, so
+``mean_coefficient_`` is an importance magnitude and ``direction`` is not
+meaningful here (use the LASSO model for direction of effect).
+
+Call ``get_stability_report()`` for a ready-to-tabulate dict. The fitted model
+is saved by the tracebloc client as the experiment's weights artifact; download
+it, load the estimator, and read these attributes to build a selection-frequency
+panel — no raw data leaves the environment.
+
+Preprocessing (median imputation + standardisation) is fit INSIDE each CV fold
+via an sklearn Pipeline, so per-fold statistics never leak across the split.
+Class imbalance is handled with ``class_weight='balanced'``.
+"""
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin, clone
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.impute import SimpleImputer
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import RepeatedStratifiedKFold
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+framework = "sklearn"
+model_type = "tree"
+main_method = "MyModel"
+batch_size = 4
+output_classes = 2
+category = "tabular_classification"
+num_feature_points = 12
+license = "MIT"
+
+
+class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
+    """Repeated stratified-CV feature-stability wrapper around a base classifier.
+
+    ``fit`` runs ``n_splits`` x ``n_repeats`` cross-validation, fitting a fresh
+    ``Pipeline(impute -> scale -> base_estimator)`` per fold so imputation and
+    scaling are learned inside the fold (no leakage). It tracks how often each
+    feature is selected and its mean effect, plus per-fold held-out AUROC, then
+    trains one final pipeline on all rows for ``predict`` / ``predict_proba``.
+    """
+
+    def __init__(
+        self,
+        base_estimator=None,
+        n_splits=10,
+        n_repeats=10,
+        random_state=42,
+        importance_threshold=None,
+    ):
+        self.base_estimator = base_estimator
+        self.n_splits = n_splits
+        self.n_repeats = n_repeats
+        self.random_state = random_state
+        self.importance_threshold = importance_threshold
+
+    @staticmethod
+    def _build_pipeline(estimator):
+        return Pipeline(
+            [
+                ("imputer", SimpleImputer(strategy="median", keep_empty_features=True)),
+                ("scaler", StandardScaler()),
+                ("estimator", estimator),
+            ]
+        )
+
+    def _selection_signal(self, fitted_estimator, n_features):
+        """Return (selected_mask, signed_effect) for one fitted leaf estimator."""
+        if hasattr(fitted_estimator, "coef_"):
+            coef = np.ravel(fitted_estimator.coef_)
+            if coef.shape[0] != n_features:
+                coef = np.resize(coef, n_features)
+            return np.abs(coef) > 1e-8, coef
+        if hasattr(fitted_estimator, "feature_importances_"):
+            imp = np.asarray(fitted_estimator.feature_importances_, dtype=float)
+            threshold = (
+                self.importance_threshold
+                if self.importance_threshold is not None
+                else 1.0 / max(n_features, 1)
+            )
+            return imp > threshold, imp
+        # No coef_/feature_importances_ — permutation importance is out of scope for V1.
+        return np.zeros(n_features, dtype=bool), np.zeros(n_features)
+
+    def fit(self, X, y):
+        if self.base_estimator is None:
+            raise ValueError("StabilityFeatureSelector requires a base_estimator.")
+        X = np.asarray(X, dtype=float)
+        y = np.asarray(y).ravel()
+        n_features = X.shape[1]
+        self.n_features_in_ = n_features
+        self.classes_ = np.unique(y)
+
+        # StratifiedKFold needs n_splits <= smallest class count; degrade gracefully
+        # (e.g. the SDK's tiny dummy-data validation fit) instead of erroring.
+        _, class_counts = np.unique(y, return_counts=True)
+        min_class = int(class_counts.min()) if class_counts.size else 0
+        eff_splits = min(self.n_splits, min_class)
+
+        select_counts = np.zeros(n_features)
+        effect_sums = np.zeros(n_features)
+        fold_aurocs = []
+        n_folds = 0
+
+        if eff_splits >= 2:
+            splitter = RepeatedStratifiedKFold(
+                n_splits=eff_splits,
+                n_repeats=self.n_repeats,
+                random_state=self.random_state,
+            )
+            for train_idx, val_idx in splitter.split(X, y):
+                pipe = self._build_pipeline(clone(self.base_estimator))
+                pipe.fit(X[train_idx], y[train_idx])
+                selected, effect = self._selection_signal(
+                    pipe.named_steps["estimator"], n_features
+                )
+                select_counts += selected
+                effect_sums += effect
+                n_folds += 1
+                y_val = y[val_idx]
+                if np.unique(y_val).size >= 2 and hasattr(pipe, "predict_proba"):
+                    try:
+                        proba = pipe.predict_proba(X[val_idx])[:, 1]
+                        fold_aurocs.append(float(roc_auc_score(y_val, proba)))
+                    except Exception:
+                        pass
+
+        self.n_folds_total_ = n_folds
+        self.selection_frequency_ = (
+            select_counts / n_folds if n_folds else select_counts
+        )
+        self.mean_coefficient_ = effect_sums / n_folds if n_folds else effect_sums
+        self.fold_aurocs_ = fold_aurocs
+
+        # Final model on all rows — used for predict/predict_proba and weight export.
+        self.final_estimator_ = self._build_pipeline(
+            clone(self.base_estimator)
+        ).fit(X, y)
+        return self
+
+    def predict(self, X):
+        return self.final_estimator_.predict(np.asarray(X, dtype=float))
+
+    def predict_proba(self, X):
+        return self.final_estimator_.predict_proba(np.asarray(X, dtype=float))
+
+    def get_stability_report(self):
+        """Plain dict of the stability results, ready to tabulate or store as JSON."""
+        freq = np.asarray(getattr(self, "selection_frequency_", []))
+        eff = np.asarray(getattr(self, "mean_coefficient_", []))
+        features = [
+            {
+                "feature_index": int(i),
+                "selection_frequency": float(freq[i]),
+                "mean_effect": float(eff[i]),
+                "direction": int(np.sign(eff[i])),
+            }
+            for i in range(len(freq))
+        ]
+        features.sort(key=lambda d: d["selection_frequency"], reverse=True)
+        aurocs = [float(a) for a in getattr(self, "fold_aurocs_", [])]
+        summary = {}
+        if aurocs:
+            summary = {
+                "auroc_mean": float(np.mean(aurocs)),
+                "auroc_std": float(np.std(aurocs)),
+                "auroc_min": float(np.min(aurocs)),
+                "auroc_max": float(np.max(aurocs)),
+                "n_folds": int(getattr(self, "n_folds_total_", 0)),
+            }
+        return {"features": features, "fold_aurocs": aurocs, "summary": summary}
+
+
+def MyModel():
+    return StabilityFeatureSelector(
+        base_estimator=RandomForestClassifier(
+            n_estimators=200,
+            class_weight="balanced",
+            random_state=42,
+        ),
+        n_splits=10,
+        n_repeats=10,
+        random_state=42,
+    )

--- a/model_zoo/text_classification/pytorch/gte_modernbert.py
+++ b/model_zoo/text_classification/pytorch/gte_modernbert.py
@@ -4,9 +4,10 @@ Requirements:
 - HuggingFace token NOT required (ungated), but recommended to avoid
   Hub rate-limits. If you set one, read it from env — never commit a
   token to this file.
-- ``trust_remote_code=True`` is required — gte-modernbert ships custom
-  modeling code. First load downloads the remote code; on slow networks
-  this step alone can take a minute.
+- No ``trust_remote_code`` needed — gte-modernbert's config declares
+  ``model_type="modernbert"``, which transformers (>=4.48) loads with
+  the **native** ``ModernBertForSequenceClassification`` class. Avoiding
+  remote code is required to pass the platform's model-security check.
 - Resources: ~600MB download, ~2GB RAM for load. ~8GB system RAM is
   enough for the local SDK self-check. At ``sequence_length=512,
   batch_size=4`` expect ~1 minute on CPU; if it looks stuck on a
@@ -29,5 +30,5 @@ output_classes = 5
 
 def MyModel(num_classes=output_classes):
     return AutoModelForSequenceClassification.from_pretrained(
-        model_id, num_labels=num_classes, trust_remote_code=True, ignore_mismatched_sizes=True
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
     )

--- a/model_zoo/text_classification/pytorch/phi_3_mini.py
+++ b/model_zoo/text_classification/pytorch/phi_3_mini.py
@@ -5,8 +5,10 @@ Requirements:
   token avoids HF Hub rate-limits on cold pulls. If you set one, read
   it from env — DO NOT commit a token to this file; uploaded files
   leak any secret embedded in them.
-- ``trust_remote_code=True`` is required — Phi-3 ships custom modeling
-  code that HF downloads on first load.
+- No ``trust_remote_code`` needed — Phi-3's config declares
+  ``model_type="phi3"``, which transformers loads with the native
+  ``Phi3ForSequenceClassification`` class. Avoiding remote code is
+  required to pass the platform's model-security check.
 - Resources: ~8GB download (fp32), ~16GB RAM for load. ~32GB system
   RAM strongly recommended for the local SDK self-check; the CPU
   forward+backward on synthetic data takes 5-15 minutes on a laptop
@@ -33,6 +35,5 @@ def MyModel(num_classes=output_classes):
     return AutoModelForSequenceClassification.from_pretrained(
         model_id,
         num_labels=num_classes,
-        trust_remote_code=True,
         ignore_mismatched_sizes=True,
     )

--- a/tests/test_stability_selection.py
+++ b/tests/test_stability_selection.py
@@ -1,0 +1,79 @@
+"""Behavioural tests for the stability-selection tabular models.
+
+Fast + deterministic (fixed seeds, reduced CV). Exercises the binary
+classification path: is_classifier compliance, per-feature selection
+frequency, held-out AUROC, predict/predict_proba, and the tiny-n guard
+that lets the SDK's dummy-data validation fit succeed.
+"""
+import importlib.util
+import pathlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip("sklearn")
+from sklearn.base import is_classifier  # noqa: E402
+
+ROOT = pathlib.Path(__file__).parent.parent
+SKL = ROOT / "model_zoo" / "tabular_classification" / "sklearn"
+FILES = ["logistic_regression_stability.py", "random_forest_stability.py"]
+
+
+def _load(fname):
+    spec = importlib.util.spec_from_file_location(fname[:-3], SKL / fname)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _data(seed=0, n_per=30, p=8, nan_frac=0.1):
+    rng = np.random.default_rng(seed)
+    n = 2 * n_per
+    X = rng.normal(size=(n, p))
+    y = np.array([1] * n_per + [0] * n_per)
+    X[:n_per, 0] += 2.0   # informative
+    X[:n_per, 1] -= 2.0   # informative
+    X[rng.random((n, p)) < nan_frac] = np.nan  # missing values, like real proteomics
+    idx = rng.permutation(n)
+    return X[idx], y[idx]
+
+
+@pytest.mark.parametrize("fname", FILES)
+def test_is_classifier(fname):
+    assert is_classifier(_load(fname).MyModel())
+
+
+@pytest.mark.parametrize("fname", FILES)
+def test_fit_reports_stability(fname):
+    mod = _load(fname)
+    base = mod.MyModel().base_estimator
+    model = mod.StabilityFeatureSelector(
+        base_estimator=base, n_splits=3, n_repeats=2, random_state=0
+    )
+    X, y = _data()
+    model.fit(X, y)
+    report = model.get_stability_report()
+
+    assert len(model.selection_frequency_) == X.shape[1]
+    assert len(report["features"]) == X.shape[1]
+    assert model.fold_aurocs_ and all(0.0 <= a <= 1.0 for a in model.fold_aurocs_)
+
+    freq = {f["feature_index"]: f["selection_frequency"] for f in report["features"]}
+    # informative features are selected often; more often than the noisy tail on average
+    assert freq[0] > 0.5 and freq[1] > 0.5
+    noise = [freq[i] for i in range(2, X.shape[1])]
+    assert min(freq[0], freq[1]) > sum(noise) / len(noise)
+
+    assert model.predict(X).shape == (len(y),)
+    assert model.predict_proba(X).shape == (len(y), 2)
+
+
+@pytest.mark.parametrize("fname", FILES)
+def test_tiny_n_does_not_raise(fname):
+    # mirrors the SDK's dummy-data validation fit on a handful of rows
+    mod = _load(fname)
+    model = mod.MyModel()
+    X = np.random.RandomState(0).normal(size=(4, 12))
+    y = np.array([0, 1, 0, 1])
+    model.fit(X, y)
+    assert model.predict(X).shape == (4,)


### PR DESCRIPTION
## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly new model-zoo assets, docs, tests, and CI gating; HF load-path tweaks are intentional security hardening with limited runtime surface beyond model upload checks.
> 
> **Overview**
> Adds a **FR gate** GitHub Actions caller that blocks PRs into `staging` / `main` / `master` unless linked kanban items are in the right “ready” state, delegating to the shared `tracebloc/.github` workflow.
> 
> Introduces **tabular stability-selection** sklearn models (LASSO logistic regression and random forest) that run repeated stratified CV inside a single `fit`, leak-safe per-fold preprocessing, and expose `get_stability_report()` on the saved weights artifact; the tabular README documents platform usage (1 epoch/cycle) and how to reload pickled results.
> 
> **Hardens several Hugging Face model zoo entries** by dropping `trust_remote_code` where native transformers classes apply (`aimv2`, GTE-ModernBERT, Phi-3-mini) so uploads pass the platform security check. Adds behavioral tests for the new stability models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e99cf6ade4765dbb4303b276d4f12dfc6c37291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->