### PR TITLE
fix(tabular/stability): address bugbot findings on #89

### DIFF
--- a/model_zoo/tabular_classification/sklearn/logistic_regression_stability.py
+++ b/model_zoo/tabular_classification/sklearn/logistic_regression_stability.py
@@ -75,10 +75,15 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
     def _selection_signal(self, fitted_estimator, n_features):
         """Return (selected_mask, signed_effect) for one fitted leaf estimator."""
         if hasattr(fitted_estimator, "coef_"):
-            coef = np.ravel(fitted_estimator.coef_)
-            if coef.shape[0] != n_features:
-                coef = np.resize(coef, n_features)
-            return np.abs(coef) > 1e-8, coef
+            coef = np.atleast_2d(np.asarray(fitted_estimator.coef_, dtype=float))
+            # Binary logreg has shape (1, n_features); multiclass has (n_classes, n_features).
+            # Use the per-feature coefficient with the largest magnitude so both
+            # the selected mask and the signed effect stay meaningful across classes.
+            if coef.shape[1] != n_features:
+                return np.zeros(n_features, dtype=bool), np.zeros(n_features)
+            argmax_class = np.argmax(np.abs(coef), axis=0)
+            signed = coef[argmax_class, np.arange(n_features)]
+            return np.abs(signed) > 1e-8, signed
         if hasattr(fitted_estimator, "feature_importances_"):
             imp = np.asarray(fitted_estimator.feature_importances_, dtype=float)
             threshold = (
@@ -110,7 +115,8 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
         fold_aurocs = []
         n_folds = 0
 
-        if eff_splits >= 2:
+        # Stratified CV needs >=2 classes overall AND enough samples per class.
+        if eff_splits >= 2 and self.classes_.size >= 2:
             splitter = RepeatedStratifiedKFold(
                 n_splits=eff_splits,
                 n_repeats=self.n_repeats,
@@ -128,8 +134,14 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
                 y_val = y[val_idx]
                 if np.unique(y_val).size >= 2 and hasattr(pipe, "predict_proba"):
                     try:
-                        proba = pipe.predict_proba(X[val_idx])[:, 1]
-                        fold_aurocs.append(float(roc_auc_score(y_val, proba)))
+                        proba = pipe.predict_proba(X[val_idx])
+                        if proba.shape[1] == 2:
+                            score = roc_auc_score(y_val, proba[:, 1])
+                        else:
+                            score = roc_auc_score(
+                                y_val, proba, multi_class="ovr", labels=self.classes_
+                            )
+                        fold_aurocs.append(float(score))
                     except Exception:
                         pass
 

--- a/model_zoo/tabular_classification/sklearn/random_forest_stability.py
+++ b/model_zoo/tabular_classification/sklearn/random_forest_stability.py
@@ -115,7 +115,8 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
         fold_aurocs = []
         n_folds = 0
 
-        if eff_splits >= 2:
+        # Stratified CV needs >=2 classes overall AND enough samples per class.
+        if eff_splits >= 2 and self.classes_.size >= 2:
             splitter = RepeatedStratifiedKFold(
                 n_splits=eff_splits,
                 n_repeats=self.n_repeats,
@@ -133,8 +134,14 @@ class StabilityFeatureSelector(ClassifierMixin, BaseEstimator):
                 y_val = y[val_idx]
                 if np.unique(y_val).size >= 2 and hasattr(pipe, "predict_proba"):
                     try:
-                        proba = pipe.predict_proba(X[val_idx])[:, 1]
-                        fold_aurocs.append(float(roc_auc_score(y_val, proba)))
+                        proba = pipe.predict_proba(X[val_idx])
+                        if proba.shape[1] == 2:
+                            score = roc_auc_score(y_val, proba[:, 1])
+                        else:
+                            score = roc_auc_score(
+                                y_val, proba, multi_class="ovr", labels=self.classes_
+                            )
+                        fold_aurocs.append(float(score))
                     except Exception:
                         pass
 


### PR DESCRIPTION
## Summary
Addresses the two Cursor Bugbot findings on [#89](https://github.com/tracebloc/model-zoo/pull/89) for the stability-selection sklearn models.

- **Single-class labels crash fit** (both files): with one class, `min_class` is large so `eff_splits >= 2` was true, then `RepeatedStratifiedKFold.split` raised. Now also require `self.classes_.size >= 2` before entering CV — the model degrades to just fitting the final pipeline.
- **Multiclass coef resize corrupts selection** (logreg only): for multiclass L1 logreg, `coef_` is `(n_classes, n_features)`; ravel + `np.resize(n_features)` kept only class 0. Now picks the per-feature signed coefficient with largest magnitude across classes. Binary behavior unchanged.
- **AUROC for multiclass**: `predict_proba[:, 1]` only works for binary. When `proba.shape[1] > 2`, switch to `roc_auc_score(..., multi_class="ovr", labels=self.classes_)`.

## Test plan
- [ ] `pytest tests/test_stability_selection.py` (local numpy is broken on the dev machine — verify in CI)
- [ ] Smoke: fit with single-class `y` no longer raises
- [ ] Smoke: 3-class `y` produces sensible `selection_frequency_` and AUROC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bug fixes in CV gating and metric/feature extraction; behavior improves for single-class and multiclass without changing the core training API.
> 
> **Overview**
> Fixes stability-selection **fit** crashes and wrong metrics for edge-case labels in the LASSO logreg and random forest sklearn tabular models.
> 
> **Single-class labels:** CV now runs only when there are at least two classes (`self.classes_.size >= 2`), not just when `eff_splits >= 2`. That avoids `RepeatedStratifiedKFold` failing on one-class `y`; the wrapper still fits the final pipeline on all data.
> 
> **LASSO logreg multiclass coefficients:** `_selection_signal` no longer ravels/resizes `coef_`, which only reflected class 0 for shape `(n_classes, n_features)`. It uses the signed coefficient with largest magnitude per feature for selection frequency and mean effect; binary behavior is unchanged.
> 
> **Fold AUROC (both models):** Held-out scoring uses the positive-class column for binary `predict_proba`, and one-vs-rest AUROC with `labels=self.classes_` when there are more than two classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45adbcb58e9746b86fae5a6f9ad1829d5abdff82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->