### PR TITLE
Merge pull request #88 from tracebloc/fix/mlm-warmstart-class-entrypoint

### DIFF
--- a/model_zoo/masked_language_modeling/pytorch/netmedgpt_style_warmstart.py
+++ b/model_zoo/masked_language_modeling/pytorch/netmedgpt_style_warmstart.py
@@ -1,36 +1,51 @@
-"""BERT-base warm-started from HuggingFace pretrained weights, adapted for MLM on custom vocab. Fine-tune on domain corpora."""
+"""BERT-base warm-started from HuggingFace pretrained weights, adapted for MLM. Fine-tune on domain corpora."""
+import torch.nn as nn
 from transformers import AutoConfig, AutoModelForMaskedLM
 
 framework = "pytorch"
-main_method = "NetMedGPTWarmStart"
+main_class = "NetMedGPTWarmStart"
 category = "masked_language_modeling"
 model_type = ""
 batch_size = 16
 sequence_length = 128
-vocab_size = 30000
+# Must match the bert-base-uncased tokenizer's vocab (30522). The previous
+# value (30000) shrank the embedding table below the tokenizer, so token ids
+# 30000-30521 caused CUDA index-out-of-bounds at training time.
+vocab_size = 30522
 
 # HuggingFace model to warm-start from
 pretrained_model_id = "bert-base-uncased"
 
 
-def NetMedGPTWarmStart(vocab_size=vocab_size):
-    """Load BERT-base-uncased and resize embeddings for a custom vocabulary.
+class NetMedGPTWarmStart(nn.Module):
+    """BERT-base-uncased warm-started from pretrained weights for MLM.
 
     Warm-starting from general-domain pretrained weights accelerates
     convergence on biomedical corpora compared to training from scratch.
-    The embedding layer and LM head are resized to match the custom
-    tokenizer's vocabulary — new token embeddings are randomly initialized
-    while existing ones retain their pretrained values.
+    The embedding layer and LM head are resized to the configured vocab —
+    new token embeddings are randomly initialized while existing ones
+    retain their pretrained values.
 
-    Returns an ``AutoModelForMaskedLM`` instance whose ``.forward()``
-    accepts ``input_ids``, ``attention_mask``, and ``labels``, returning
-    a ``MaskedLMOutput`` with ``.loss`` and ``.logits``.
+    ``forward`` accepts ``input_ids``, ``attention_mask`` and ``labels``
+    and returns a ``MaskedLMOutput`` with ``.loss`` and ``.logits``.
+
+    Authored as an ``nn.Module`` subclass (``main_class``) rather than a
+    factory function (``main_method``): the platform's model loader resolves
+    the class entrypoint reliably, whereas the factory-function form failed
+    to load server-side.
     """
-    config = AutoConfig.from_pretrained(pretrained_model_id)
-    model = AutoModelForMaskedLM.from_pretrained(
-        pretrained_model_id,
-        config=config,
-        ignore_mismatched_sizes=True,
-    )
-    model.resize_token_embeddings(vocab_size)
-    return model
+
+    def __init__(self, vocab_size=vocab_size):
+        super(NetMedGPTWarmStart, self).__init__()
+        config = AutoConfig.from_pretrained(pretrained_model_id)
+        self.model = AutoModelForMaskedLM.from_pretrained(
+            pretrained_model_id,
+            config=config,
+            ignore_mismatched_sizes=True,
+        )
+        self.model.resize_token_embeddings(vocab_size)
+
+    def forward(self, input_ids, attention_mask=None, labels=None, **kwargs):
+        return self.model(
+            input_ids=input_ids, attention_mask=attention_mask, labels=labels
+        )


### PR DESCRIPTION
fix(mlm): make netmedgpt_style_warmstart loadable (class entrypoint + vocab)

## Summary
<!-- 1–3 sentences. What does this PR do and why? -->

## Related
<!-- Closes #123 / Ref tracebloc/other-repo#456 -->

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Tech-debt / refactor
- [ ] Docs
- [ ] Security / hardening
- [ ] Breaking change

## Test plan
<!-- What did you test? Commands run? Manual steps? -->

## Screenshots / recordings
<!-- For UI changes. Remove if N/A. -->

## Deployment notes
<!-- Env vars, migrations, rollout order, feature flags. Remove if N/A. -->

## Checklist
- [ ] Tests added / updated and passing locally
- [ ] Docs updated if behavior or config changed
- [ ] No secrets / credentials in the diff
- [ ] For security-sensitive paths: appropriate reviewer requested

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single model-zoo file change; corrects vocab sizing and loader entrypoint with no auth, data, or API surface impact.
> 
> **Overview**
> Fixes **NetMedGPT warm-start** so the model zoo entry loads on the platform and MLM training no longer crashes on out-of-range token IDs.
> 
> **`vocab_size`** is raised from **30000** to **30522** to align with **`bert-base-uncased`**. The smaller table left embeddings undersized relative to the tokenizer, so IDs **30000–30521** triggered CUDA index-out-of-bounds during training.
> 
> The entrypoint switches from a **`main_method` factory** to a **`main_class` `nn.Module`** (`NetMedGPTWarmStart`) that wraps **`AutoModelForMaskedLM`**, warm-starts from **`bert-base-uncased`**, resizes token embeddings, and delegates **`forward`** to the HF model—matching how other zoo models expose **`main_class`** for reliable server-side loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf2538b5477646594e29eab313800c06640ea0cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->