### PR TITLE
fix(tabular): multi-class heads + NaN handling for tabular_classification

### DIFF
--- a/model_zoo/tabular_classification/pytorch/cnn.py
+++ b/model_zoo/tabular_classification/pytorch/cnn.py
@@ -1,4 +1,5 @@
 """1D CNN for tabular classification. Pick when feature order is meaningful (e.g. sequential or spatial tabular data)."""
+import torch
 import torch.nn as nn
 
 framework = "pytorch"
@@ -16,16 +17,17 @@ class SimpleCNN(nn.Module):
         self.conv2 = nn.Conv1d(in_channels=16, out_channels=32, kernel_size=3, padding=1)
         self.fc1 = nn.Linear(32 * input_size, 128)  # input_size is the total number of features
         self.fc2 = nn.Linear(128, 64)
-        self.fc3 = nn.Linear(64, 1)
+        self.fc3 = nn.Linear(64, output_classes)
         self.relu = nn.ReLU()
         self.sigmoid = nn.Sigmoid()
 
     def forward(self, x):
+        x = torch.nan_to_num(x)
         x = x.unsqueeze(1)  # Add a channel dimension for Conv1D (batch_size, channels, input_size)
         x = self.relu(self.conv1(x))
         x = self.relu(self.conv2(x))
         x = x.view(x.size(0), -1)  # Flatten before feeding into FC layers
         x = self.relu(self.fc1(x))
         x = self.relu(self.fc2(x))
-        x = self.sigmoid(self.fc3(x))
+        x = self.fc3(x)
         return x

--- a/model_zoo/tabular_classification/pytorch/fcn.py
+++ b/model_zoo/tabular_classification/pytorch/fcn.py
@@ -1,4 +1,5 @@
 """Fully Connected Network (MLP) for tabular classification. Default choice when features have no inherent ordering."""
+import torch
 import torch.nn as nn
 
 framework = "pytorch"
@@ -14,12 +15,13 @@ class SimpleFCN(nn.Module):
         super(SimpleFCN, self).__init__()
         self.fc1 = nn.Linear(num_feature_points, 128)
         self.fc2 = nn.Linear(128, 64)
-        self.fc3 = nn.Linear(64, 1)
+        self.fc3 = nn.Linear(64, output_classes)
         self.relu = nn.ReLU()
         self.sigmoid = nn.Sigmoid()
 
     def forward(self, x):
+        x = torch.nan_to_num(x)
         x = self.relu(self.fc1(x))
         x = self.relu(self.fc2(x))
-        x = self.sigmoid(self.fc3(x))
+        x = self.fc3(x)
         return x

--- a/model_zoo/tabular_classification/pytorch/ft_transformer.py
+++ b/model_zoo/tabular_classification/pytorch/ft_transformer.py
@@ -40,6 +40,7 @@ class MyModel(nn.Module):
         self.head = nn.Linear(d_token, num_classes)
 
     def forward(self, x):
+        x = torch.nan_to_num(x)
         tokens = self.tokenizer(x)
         h = self.encoder(tokens)
         return self.head(self.norm(h[:, 0]))

--- a/model_zoo/tabular_classification/pytorch/lstm.py
+++ b/model_zoo/tabular_classification/pytorch/lstm.py
@@ -21,7 +21,9 @@ class SimpleLSTM(nn.Module):
 
     def forward(self, x):
         x = torch.nan_to_num(x)
-        x, _ = self.lstm(x)  # LSTM returns the output and hidden states
+        x = x.unsqueeze(1)  # (B, F) -> (B, 1, F): treat each row as a length-1 sequence
+        out, _ = self.lstm(x)  # (B, 1, hidden)
+        x = out[:, -1, :]  # (B, hidden): last timestep -> 2D for the (B, output_classes) head
         x = self.relu(self.fc1(x))
         x = self.fc2(x)
         return x

--- a/model_zoo/tabular_classification/pytorch/lstm.py
+++ b/model_zoo/tabular_classification/pytorch/lstm.py
@@ -1,4 +1,5 @@
 """LSTM for tabular classification. Pick when rows represent sequences or time-ordered features."""
+import torch
 import torch.nn as nn
 
 framework = "pytorch"
@@ -14,13 +15,14 @@ class SimpleLSTM(nn.Module):
         super(SimpleLSTM, self).__init__()
         self.lstm = nn.LSTM(input_size=input_size, hidden_size=hidden_size, num_layers=num_layers, batch_first=True)
         self.fc1 = nn.Linear(hidden_size, 64)
-        self.fc2 = nn.Linear(64, 1)
+        self.fc2 = nn.Linear(64, output_classes)
         self.relu = nn.ReLU()
         self.sigmoid = nn.Sigmoid()
 
     def forward(self, x):
+        x = torch.nan_to_num(x)
         x, _ = self.lstm(x)  # LSTM returns the output and hidden states
         x = self.relu(self.fc1(x))
-        x = self.sigmoid(self.fc2(x))
+        x = self.fc2(x)
         return x
 

--- a/model_zoo/tabular_classification/pytorch/rnn.py
+++ b/model_zoo/tabular_classification/pytorch/rnn.py
@@ -21,8 +21,9 @@ class SimpleRNN(nn.Module):
 
     def forward(self, x):
         x = torch.nan_to_num(x)
-        # Assuming input shape is (batch_size, sequence_length, input_size)
-        x, _ = self.rnn(x)  # RNN returns the output and hidden states
+        x = x.unsqueeze(1)  # (B, F) -> (B, 1, F): treat each row as a length-1 sequence
+        out, _ = self.rnn(x)  # (B, 1, hidden)
+        x = out[:, -1, :]  # (B, hidden): last timestep -> 2D for the (B, output_classes) head
         x = self.relu(self.fc1(x))
         x = self.fc2(x)
         return x

--- a/model_zoo/tabular_classification/pytorch/rnn.py
+++ b/model_zoo/tabular_classification/pytorch/rnn.py
@@ -1,4 +1,5 @@
 """Simple RNN for tabular classification. Lighter than LSTM; use for short sequences."""
+import torch
 import torch.nn as nn
 
 framework = "pytorch"
@@ -14,13 +15,14 @@ class SimpleRNN(nn.Module):
         super(SimpleRNN, self).__init__()
         self.rnn = nn.RNN(input_size=input_size, hidden_size=hidden_size, num_layers=num_layers, batch_first=True)
         self.fc1 = nn.Linear(hidden_size, 64)
-        self.fc2 = nn.Linear(64, 1)
+        self.fc2 = nn.Linear(64, output_classes)
         self.relu = nn.ReLU()
         self.sigmoid = nn.Sigmoid()
 
     def forward(self, x):
+        x = torch.nan_to_num(x)
         # Assuming input shape is (batch_size, sequence_length, input_size)
         x, _ = self.rnn(x)  # RNN returns the output and hidden states
         x = self.relu(self.fc1(x))
-        x = self.sigmoid(self.fc2(x))
+        x = self.fc2(x)
         return x

--- a/model_zoo/tabular_classification/pytorch/tabm.py
+++ b/model_zoo/tabular_classification/pytorch/tabm.py
@@ -40,6 +40,7 @@ class MyModel(nn.Module):
         self.act = nn.GELU()
 
     def forward(self, x):
+        x = torch.nan_to_num(x)
         b = x.shape[0]
         x = x.unsqueeze(1).expand(b, self.k, -1)  # (B, K, F)
         x = self.act(self.norm1(self.l1(x)))

--- a/model_zoo/tabular_classification/sklearn/decision_tree.py
+++ b/model_zoo/tabular_classification/sklearn/decision_tree.py
@@ -1,5 +1,8 @@
 from sklearn.tree import DecisionTreeClassifier
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "tree"
 main_method = "MyModel"
@@ -9,4 +12,4 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    return DecisionTreeClassifier(random_state=42)
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", DecisionTreeClassifier(random_state=42))])

--- a/model_zoo/tabular_classification/sklearn/ensemble.py
+++ b/model_zoo/tabular_classification/sklearn/ensemble.py
@@ -3,6 +3,9 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.svm import SVC
 from sklearn.ensemble import GradientBoostingClassifier
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "ensemble"
 main_method = "MyModel"
@@ -19,4 +22,4 @@ def MyModel():
         estimators=[('gbm', gbm), ('svm', svm)],
         final_estimator=LogisticRegression(random_state=42)
     )
-    return stacked_model
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", stacked_model)])

--- a/model_zoo/tabular_classification/sklearn/ensemble.py
+++ b/model_zoo/tabular_classification/sklearn/ensemble.py
@@ -15,11 +15,16 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    gbm = GradientBoostingClassifier(n_estimators=100, learning_rate=0.1, random_state=42)
-    svm = SVC(probability=True, kernel="rbf", random_state=42)
-
-    stacked_model = StackingClassifier(
-        estimators=[('gbm', gbm), ('svm', svm)],
-        final_estimator=LogisticRegression(random_state=42)
+    # Impute inside each base estimator so the imputer is refit within
+    # StackingClassifier's internal CV folds. An outer imputer would fit on all
+    # training rows before that CV and leak validation-fold values into the
+    # meta-features / meta-learner.
+    gbm = Pipeline([("imputer", SimpleImputer(strategy="median")),
+                    ("clf", GradientBoostingClassifier(n_estimators=100, learning_rate=0.1, random_state=42))])
+    svm = Pipeline([("imputer", SimpleImputer(strategy="median")),
+                    ("clf", SVC(probability=True, kernel="rbf", random_state=42))])
+    # final_estimator only sees base-model predictions (no NaN) -> no imputer needed.
+    return StackingClassifier(
+        estimators=[("gbm", gbm), ("svm", svm)],
+        final_estimator=LogisticRegression(random_state=42),
     )
-    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", stacked_model)])

--- a/model_zoo/tabular_classification/sklearn/gbm.py
+++ b/model_zoo/tabular_classification/sklearn/gbm.py
@@ -1,6 +1,9 @@
 from sklearn.ensemble import GradientBoostingClassifier
 
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "tree"
 main_method = "MyModel"
@@ -11,4 +14,4 @@ num_feature_points = 50
 
 def MyModel():
     model = GradientBoostingClassifier(n_estimators=100, random_state=42)
-    return model
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", model)])

--- a/model_zoo/tabular_classification/sklearn/knn.py
+++ b/model_zoo/tabular_classification/sklearn/knn.py
@@ -1,5 +1,8 @@
 from sklearn.neighbors import KNeighborsClassifier
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "clustering"
 main_method = "MyModel"
@@ -9,4 +12,4 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    return KNeighborsClassifier(n_neighbors=5)
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", KNeighborsClassifier(n_neighbors=5))])

--- a/model_zoo/tabular_classification/sklearn/logistic_regression.py
+++ b/model_zoo/tabular_classification/sklearn/logistic_regression.py
@@ -1,5 +1,8 @@
 from sklearn.linear_model import LogisticRegression
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "linear"
 main_method = "MyModel"
@@ -9,4 +12,4 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    return LogisticRegression(random_state=42)
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", LogisticRegression(random_state=42))])

--- a/model_zoo/tabular_classification/sklearn/mlp.py
+++ b/model_zoo/tabular_classification/sklearn/mlp.py
@@ -1,5 +1,8 @@
 from sklearn.neural_network import MLPClassifier
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "neural_network"
 main_method = "MyModel"
@@ -9,4 +12,4 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    return MLPClassifier()
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", MLPClassifier())])

--- a/model_zoo/tabular_classification/sklearn/naive_bayes.py
+++ b/model_zoo/tabular_classification/sklearn/naive_bayes.py
@@ -1,5 +1,8 @@
 from sklearn.naive_bayes import GaussianNB
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "naive"
 main_method = "MyModel"
@@ -9,4 +12,4 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    return GaussianNB()
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", GaussianNB())])

--- a/model_zoo/tabular_classification/sklearn/random_forest.py
+++ b/model_zoo/tabular_classification/sklearn/random_forest.py
@@ -1,5 +1,8 @@
 from sklearn.ensemble import RandomForestClassifier
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "tree"
 main_method = "MyModel"
@@ -9,4 +12,4 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    return RandomForestClassifier(n_estimators=100, random_state=42)
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", RandomForestClassifier(n_estimators=100, random_state=42))])

--- a/model_zoo/tabular_classification/sklearn/svm.py
+++ b/model_zoo/tabular_classification/sklearn/svm.py
@@ -1,5 +1,8 @@
 from sklearn.svm import SVC
 
+from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
+
 framework = "sklearn"
 model_type = "svm"
 main_method = "MyModel"
@@ -9,4 +12,4 @@ category = "tabular_classification"
 num_feature_points = 50
 
 def MyModel():
-    return SVC(kernel='linear')
+    return Pipeline([("imputer", SimpleImputer(strategy="median")), ("clf", SVC(kernel='linear'))])

--- a/model_zoo/tabular_classification/tensorflow/cnn.py
+++ b/model_zoo/tabular_classification/tensorflow/cnn.py
@@ -1,4 +1,5 @@
 """1D CNN for tabular classification (TensorFlow). Pick when feature order is meaningful."""
+import tensorflow as tf
 from tensorflow.keras import layers, models
 
 framework = "tensorflow"
@@ -10,16 +11,17 @@ num_feature_points = 50
 category = "tabular_classification"
 
 
-def MyModel(input_size=num_feature_points, n_outputs=1):
+def MyModel(input_size=num_feature_points, n_outputs=output_classes):
     model = models.Sequential(
         [
             layers.Input(shape=(input_size, 1)),
+            layers.Lambda(lambda t: tf.where(tf.math.is_nan(t), tf.zeros_like(t), t)),
             layers.Conv1D(16, 3, padding="same", activation="relu"),
             layers.Conv1D(32, 3, padding="same", activation="relu"),
             layers.Flatten(),
             layers.Dense(128, activation="relu"),
             layers.Dense(64, activation="relu"),
-            layers.Dense(n_outputs, activation="sigmoid"),
+            layers.Dense(n_outputs, activation="softmax"),
         ]
     )
     return model

--- a/model_zoo/tabular_classification/tensorflow/fcn.py
+++ b/model_zoo/tabular_classification/tensorflow/fcn.py
@@ -1,4 +1,5 @@
 """Fully Connected Network for tabular classification (TensorFlow). Default MLP baseline."""
+import tensorflow as tf
 from tensorflow.keras import layers, models
 
 framework = "tensorflow"
@@ -10,13 +11,14 @@ num_feature_points = 50
 category = "tabular_classification"
 
 
-def MyModel(input_shape=(num_feature_points,), n_outputs=1):
+def MyModel(input_shape=(num_feature_points,), n_outputs=output_classes):
     model = models.Sequential(
         [
             layers.Input(shape=input_shape),
+            layers.Lambda(lambda t: tf.where(tf.math.is_nan(t), tf.zeros_like(t), t)),
             layers.Dense(128, activation="relu"),
             layers.Dense(64, activation="relu"),
-            layers.Dense(n_outputs, activation="sigmoid"),
+            layers.Dense(n_outputs, activation="softmax"),
         ]
     )
     return model

--- a/model_zoo/tabular_classification/tensorflow/lstm.py
+++ b/model_zoo/tabular_classification/tensorflow/lstm.py
@@ -1,4 +1,5 @@
 """LSTM for tabular classification (TensorFlow). Pick when rows represent sequences."""
+import tensorflow as tf
 from tensorflow.keras import layers, models
 
 framework = "tensorflow"
@@ -10,10 +11,11 @@ num_feature_points = 50
 category = "tabular_classification"
 
 
-def MyModel(input_size=num_feature_points, hidden_size=128, n_outputs=1):
+def MyModel(input_size=num_feature_points, hidden_size=128, n_outputs=output_classes):
     inputs = layers.Input(shape=(input_size,))
-    x = layers.Reshape((1, input_size))(inputs)
+    x = layers.Lambda(lambda t: tf.where(tf.math.is_nan(t), tf.zeros_like(t), t))(inputs)
+    x = layers.Reshape((1, input_size))(x)
     x = layers.LSTM(hidden_size)(x)
     x = layers.Dense(64, activation="relu")(x)
-    outputs = layers.Dense(n_outputs, activation="sigmoid")(x)
+    outputs = layers.Dense(n_outputs, activation="softmax")(x)
     return models.Model(inputs, outputs)

--- a/model_zoo/tabular_classification/tensorflow/rnn.py
+++ b/model_zoo/tabular_classification/tensorflow/rnn.py
@@ -1,4 +1,5 @@
 """Simple RNN for tabular classification (TensorFlow). Lighter than LSTM."""
+import tensorflow as tf
 from tensorflow.keras import layers, models
 
 framework = "tensorflow"
@@ -9,10 +10,12 @@ output_classes = 5
 num_feature_points = 50
 category = "tabular_classification"
 
-def MyModel(input_size=num_feature_points, hidden_size=128, n_outputs=1):
+
+def MyModel(input_size=num_feature_points, hidden_size=128, n_outputs=output_classes):
     inputs = layers.Input(shape=(input_size,))
-    x = layers.Reshape((1, input_size))(inputs)
+    x = layers.Lambda(lambda t: tf.where(tf.math.is_nan(t), tf.zeros_like(t), t))(inputs)
+    x = layers.Reshape((1, input_size))(x)
     x = layers.SimpleRNN(hidden_size)(x)
     x = layers.Dense(64, activation="relu")(x)
-    outputs = layers.Dense(n_outputs, activation="sigmoid")(x)
+    outputs = layers.Dense(n_outputs, activation="softmax")(x)
     return models.Model(inputs, outputs)


### PR DESCRIPTION
## What
Make the `tabular_classification` zoo work for **multi-class** targets and **datasets with missing values (NaN)**. Today every NN model is hardcoded binary (1-output + sigmoid) and no model tolerates NaN, so multi-class / real-world tabular use cases (e.g. the a customer the customer's 4-class panel and the target-discovery binary set with 30%+ missingness) fail at upload or training.

## Changes
- **pytorch** `fcn`/`cnn`/`lstm`/`rnn`: head → `nn.Linear(.., output_classes)` (logits, sigmoid removed); `torch.nan_to_num(x)` at `forward` entry.
- **pytorch** `ft_transformer`/`tabm`: `nan_to_num` (heads already use `output_classes`).
- **tensorflow** `fcn`/`cnn`/`lstm`/`rnn`: `n_outputs=output_classes`, final `Dense(output_classes, softmax)`; NaN→0 masking layer after `Input`.
- **sklearn** (9 non-NaN-native): wrapped in `Pipeline([SimpleImputer(median), clf])`. HistGB / XGBoost / LightGBM / CatBoost untouched (native NaN); stability variants already pipelined.

## Companion (required)
tracebloc-py-package PR: tabular upload validator → `CrossEntropyLoss` (not `MSELoss`). Without it, multi-class pytorch models fail upload.

## Validation
With both PRs applied: pytorch `fcn`/`tabm` (4-class) upload+link the a customer IBD use case, and sklearn `random_forest` (imputer) uploads+links the NaN-heavy target-discovery use case — both previously failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to default model outputs and preprocessing across many zoo entrypoints; incorrect loss pairing without the companion validator PR would break PyTorch multi-class training.
> 
> **Overview**
> Updates **tabular_classification** zoo models so they support **multi-class** targets and **NaN** in feature matrices instead of failing on binary-only heads and missing-value inputs.
> 
> **PyTorch** (`fcn`, `cnn`, `lstm`, `rnn`): final layers now emit **`output_classes` logits** (sigmoid removed); **`torch.nan_to_num`** runs at the start of `forward`. **LSTM/RNN** reshape flat `(B, F)` rows to `(B, 1, F)` and take the last timestep before the classifier head.
> 
> **TensorFlow** (`fcn`, `cnn`, `lstm`, `rnn`): default **`n_outputs=output_classes`** with **softmax** on the last `Dense`; a **NaN→0** `Lambda` sits right after `Input`.
> 
> **sklearn** (nine estimators): each **`MyModel()`** returns a **`Pipeline`** with **`SimpleImputer(strategy="median")`** then the classifier. **`ensemble.py`** puts imputers **inside each base estimator** so stacking CV does not leak validation-fold statistics into meta-features.
> 
> **PyTorch** `ft_transformer` / `tabm` only add **`nan_to_num`** (heads already multi-class). Native-NaN boosters (HistGB, XGBoost, etc.) are unchanged.
> 
> End-to-end multi-class PyTorch upload/training still depends on the companion **tracebloc-py-package** change to use **`CrossEntropyLoss`** instead of **`MSELoss`** on tabular classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4105b1acd96588a0d7018496b59e8035724d335b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->