### PR TITLE
feat: add token_classification (NER/POS) starter models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ model_zoo/
   image_classification/       pytorch/, tensorflow/
   object_detection/           pytorch/
   text_classification/        pytorch/
+  token_classification/       pytorch/
   semantic_segmentation/      pytorch/
   keypoint_detection/         pytorch/
   tabular_classification/     pytorch/, sklearn/, tensorflow/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Every model in this repo is compatible with tracebloc's secure training environm
 | Image classification | PyTorch, TensorFlow | `model_zoo/image_classification/` | Categorize images into labels |
 | Object detection | PyTorch | `model_zoo/object_detection/pytorch/` | Locate and classify objects in images |
 | Text classification | PyTorch | `model_zoo/text_classification/pytorch/` | Classify documents, reviews, tickets |
+| Token classification | PyTorch | `model_zoo/token_classification/pytorch/` | Tag tokens: NER, POS, slot filling |
 | Semantic segmentation | PyTorch | `model_zoo/semantic_segmentation/pytorch/` | Pixel-level image labeling |
 | Keypoint detection | PyTorch | `model_zoo/keypoint_detection/pytorch/` | Detect landmarks on objects or bodies |
 | Tabular classification | — | `model_zoo/tabular_classification/` | Classify structured/tabular data |

--- a/model_zoo/token_classification/pytorch/bert_token.py
+++ b/model_zoo/token_classification/pytorch/bert_token.py
@@ -1,0 +1,21 @@
+"""BERT-base via HuggingFace with a per-token classification head. The canonical NER/POS baseline; strong default for token-level tagging."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "bert-base-uncased"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+
+def MyModel(num_classes=output_classes):
+
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/distil_token.py
+++ b/model_zoo/token_classification/pytorch/distil_token.py
@@ -1,0 +1,21 @@
+"""DistilBERT via HuggingFace with a per-token classification head. ~60% the size of BERT-base, ~97% of its accuracy; pick when training speed or edge resources matter."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "distilbert-base-uncased"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 64
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+
+def MyModel(num_classes=output_classes):
+
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/simple_token.py
+++ b/model_zoo/token_classification/pytorch/simple_token.py
@@ -1,0 +1,89 @@
+"""Minimal transformer encoder with a per-token tag head, ~7M params. Smoke-test model for quick iteration and token-classification pipeline validation."""
+import torch
+import torch.nn as nn
+
+framework = "pytorch"
+main_class = "SimpleTokenTagger"
+category = "token_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 64
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+# Must cover the training tokenizer's vocabulary. The client's default
+# tokenizer (bert-base-uncased) has vocab_size=30522 — token IDs beyond
+# the embedding table cause index-out-of-bounds errors at training time.
+_VOCAB_SIZE = 30522
+
+
+class SimpleTokenTagger(nn.Module):
+    """Lightweight 2-layer transformer encoder for token classification.
+
+    Emits per-token logits of shape ``(batch, seq_len, output_classes)`` —
+    one BIO tag distribution per sub-word token. Intended for smoke testing
+    the token-classification training pipeline — not for production-quality
+    predictions.
+    """
+
+    def __init__(
+        self,
+        vocab_size=_VOCAB_SIZE,
+        num_labels=output_classes,
+        hidden_size=192,
+        num_layers=2,
+        num_heads=4,
+        intermediate_size=384,
+        max_position_embeddings=512,
+        dropout=0.1,
+    ):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(vocab_size, hidden_size)
+        self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
+        self.max_position_embeddings = max_position_embeddings
+        self.layer_norm = nn.LayerNorm(hidden_size)
+        self.dropout = nn.Dropout(dropout)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=hidden_size,
+            nhead=num_heads,
+            dim_feedforward=intermediate_size,
+            dropout=dropout,
+            activation="gelu",
+            batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        self.encoder.enable_nested_tensor = False
+        self.classifier = nn.Linear(hidden_size, num_labels)
+
+        self._init_weights()
+
+    def _init_weights(self):
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                module.weight.data.normal_(mean=0.0, std=0.02)
+                if module.bias is not None:
+                    module.bias.data.zero_()
+            elif isinstance(module, nn.Embedding):
+                module.weight.data.normal_(mean=0.0, std=0.02)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        seq_len = input_ids.size(1)
+        position_ids = torch.arange(seq_len, device=input_ids.device).unsqueeze(0)
+        position_ids = position_ids.clamp(max=self.max_position_embeddings - 1)
+
+        x = self.word_embeddings(input_ids) + self.position_embeddings(position_ids)
+        x = self.layer_norm(x)
+        x = self.dropout(x)
+
+        if attention_mask is not None:
+            # TransformerEncoder expects mask where True = ignore
+            src_key_padding_mask = attention_mask == 0
+        else:
+            src_key_padding_mask = None
+
+        x = self.encoder(x, src_key_padding_mask=src_key_padding_mask)
+        # Per-token logits: (batch, seq_len, num_labels)
+        return self.classifier(x)

--- a/model_zoo/token_classification/pytorch/simple_token.py
+++ b/model_zoo/token_classification/pytorch/simple_token.py
@@ -31,7 +31,7 @@ class SimpleTokenTagger(nn.Module):
     def __init__(
         self,
         vocab_size=_VOCAB_SIZE,
-        num_labels=output_classes,
+        num_classes=output_classes,
         hidden_size=192,
         num_layers=2,
         num_heads=4,
@@ -56,7 +56,7 @@ class SimpleTokenTagger(nn.Module):
         )
         self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
         self.encoder.enable_nested_tensor = False
-        self.classifier = nn.Linear(hidden_size, num_labels)
+        self.classifier = nn.Linear(hidden_size, num_classes)
 
         self._init_weights()
 
@@ -85,5 +85,5 @@ class SimpleTokenTagger(nn.Module):
             src_key_padding_mask = None
 
         x = self.encoder(x, src_key_padding_mask=src_key_padding_mask)
-        # Per-token logits: (batch, seq_len, num_labels)
+        # Per-token logits: (batch, seq_len, num_classes)
         return self.classifier(x)

--- a/tests/test_model_contract.py
+++ b/tests/test_model_contract.py
@@ -50,6 +50,7 @@ KNOWN_CATEGORIES = {
     "time_series_forecasting",
     "time_to_event_prediction",
     "masked_language_modeling",
+    "token_classification",
 }
 
 


### PR DESCRIPTION
## What

Adds the **model-zoo layer** of the cross-repo token-classification rollout — three starter models so a new token-classification use case has something to train out of the box:

| Model | What | Specs |
|---|---|---|
| `bert_token.py` | `AutoModelForTokenClassification` on `bert-base-uncased` — the canonical NER/POS baseline | batch 32 · seq 128 · classes 9 |
| `distil_token.py` | DistilBERT variant, ~60% the size of BERT-base; for training-speed / edge-resource-sensitive setups | batch 64 · seq 128 · classes 9 |
| `simple_token.py` | Scratch 2-layer encoder + per-token head, **~7M params**, no HF download — pipeline smoke-test | batch 32 · seq 64 · classes 9 |

`output_classes=9` defaults to the CoNLL BIO scheme (`O` + `B/I × {PER, ORG, LOC, MISC}`) with an in-file comment telling users to set their dataset's tag count. `simple_token` uses `vocab_size=30522` so the client's default `bert-base-uncased` tokenizer can never index out of the embedding table.

Also registers `token_classification` in the contract test's `KNOWN_CATEGORIES` and lists the new task directory in `README.md` + `CLAUDE.md`.

## Conventions

- Metadata contract (`framework` / `main_class` / `category` / `sequence_length` / `output_classes`), `license = "Apache-2.0"`, snake_case filenames.
- **No in-file PEFT/LoRA** — LoRA is selected in the training plan, per the platform rule.
- LayerNorm-only (no BatchNorm) — averaging-friendly across non-IID clients.

## Verification

- Zoo contract test passes for all three files (and fails without the `KNOWN_CATEGORIES` registration — the gate works).
- **Cross-repo functional check**: `simple_token` loaded exactly as the SDK would and driven through the new `TorchTokenClassifier` from tracebloc/tracebloc-py-package#200 — structural checks ✅, 3D `(batch, seq_len, num_labels)` logits probe with last dim == `output_classes` ✅, real training step with `-100`-masked labels (weights updated) ✅.

## Rollout context

client tracebloc/tracebloc-client#300 · ingestor tracebloc/data-ingestors#169 · backend tracebloc/backend#769 (merged, verified live on dev) · SDK tracebloc/tracebloc-py-package#200 · FE tracebloc/frontend-app#513

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model templates and documentation only; no changes to training, auth, or platform runtime behavior.
> 
> **Overview**
> Adds a new **`token_classification`** task to the model zoo with three PyTorch starters under `model_zoo/token_classification/pytorch/`: HuggingFace **BERT** and **DistilBERT** via `AutoModelForTokenClassification`, plus a small scratch **`SimpleTokenTagger`** (~7M params) that outputs per-token logits for pipeline smoke tests.
> 
> All three follow the existing metadata contract (`category`, `sequence_length`, default **`output_classes=9`** for CoNLL-style BIO tags, `Apache-2.0`). **`simple_token`** uses LayerNorm (no BatchNorm) and `vocab_size=30522` to match the default BERT tokenizer.
> 
> **Docs** (`README.md`, `CLAUDE.md`) list the new task path. **`tests/test_model_contract.py`** registers `token_classification` in `KNOWN_CATEGORIES` so zoo contract tests cover the new files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba53a5374fb328c2e0109fc93f74edc71bc8a96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->