### PR TITLE
feat(token-classification): NER/POS model set — 3 starter + 5 SOTA backbones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ model_zoo/
   image_classification/       pytorch/, tensorflow/
   object_detection/           pytorch/
   text_classification/        pytorch/
+  token_classification/       pytorch/
   semantic_segmentation/      pytorch/
   keypoint_detection/         pytorch/
   tabular_classification/     pytorch/, sklearn/, tensorflow/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Every model in this repo is compatible with tracebloc's secure training environm
 | Image classification | PyTorch, TensorFlow | `model_zoo/image_classification/` | Categorize images into labels |
 | Object detection | PyTorch | `model_zoo/object_detection/pytorch/` | Locate and classify objects in images |
 | Text classification | PyTorch | `model_zoo/text_classification/pytorch/` | Classify documents, reviews, tickets |
+| Token classification | PyTorch | `model_zoo/token_classification/pytorch/` | Tag tokens: NER, POS, slot filling |
 | Semantic segmentation | PyTorch | `model_zoo/semantic_segmentation/pytorch/` | Pixel-level image labeling |
 | Keypoint detection | PyTorch | `model_zoo/keypoint_detection/pytorch/` | Detect landmarks on objects or bodies |
 | Tabular classification | — | `model_zoo/tabular_classification/` | Classify structured/tabular data |

--- a/model_zoo/token_classification/pytorch/bert_token.py
+++ b/model_zoo/token_classification/pytorch/bert_token.py
@@ -1,0 +1,21 @@
+"""BERT-base via HuggingFace with a per-token classification head. The canonical NER/POS baseline; strong default for token-level tagging."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "bert-base-uncased"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+
+def MyModel(num_classes=output_classes):
+
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/deberta_v3_token.py
+++ b/model_zoo/token_classification/pytorch/deberta_v3_token.py
@@ -1,0 +1,20 @@
+"""DeBERTa-v3-base with a per-token classification head. Disentangled attention + ELECTRA-style pretraining; state-of-the-art on CoNLL/OntoNotes NER."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "microsoft/deberta-v3-base"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 16
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "MIT"
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/distil_token.py
+++ b/model_zoo/token_classification/pytorch/distil_token.py
@@ -1,0 +1,21 @@
+"""DistilBERT via HuggingFace with a per-token classification head. ~60% the size of BERT-base, ~97% of its accuracy; pick when training speed or edge resources matter."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "distilbert-base-uncased"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 64
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+
+def MyModel(num_classes=output_classes):
+
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/electra_token.py
+++ b/model_zoo/token_classification/pytorch/electra_token.py
@@ -1,0 +1,20 @@
+"""ELECTRA-base (discriminator) with a per-token classification head. Replaced-token-detection pretraining; strong NER at lower compute, and shares BERT's WordPiece vocab."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "google/electra-base-discriminator"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/modernbert_token.py
+++ b/model_zoo/token_classification/pytorch/modernbert_token.py
@@ -1,0 +1,20 @@
+"""ModernBERT-base with a per-token classification head. 2024 long-context encoder (8k tokens, RoPE + GeGLU); state-of-the-art accuracy/throughput for token tagging."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "answerdotai/ModernBERT-base"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 16
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/roberta_token.py
+++ b/model_zoo/token_classification/pytorch/roberta_token.py
@@ -1,0 +1,20 @@
+"""RoBERTa-base with a per-token classification head. Robustly-pretrained encoder; a stronger NER/POS baseline than vanilla BERT."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "roberta-base"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "MIT"
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/model_zoo/token_classification/pytorch/simple_token.py
+++ b/model_zoo/token_classification/pytorch/simple_token.py
@@ -1,0 +1,89 @@
+"""Minimal transformer encoder with a per-token tag head, ~7M params. Smoke-test model for quick iteration and token-classification pipeline validation."""
+import torch
+import torch.nn as nn
+
+framework = "pytorch"
+main_class = "SimpleTokenTagger"
+category = "token_classification"
+model_type = ""
+batch_size = 32
+sequence_length = 64
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "Apache-2.0"
+
+# Must cover the training tokenizer's vocabulary. The client's default
+# tokenizer (bert-base-uncased) has vocab_size=30522 — token IDs beyond
+# the embedding table cause index-out-of-bounds errors at training time.
+_VOCAB_SIZE = 30522
+
+
+class SimpleTokenTagger(nn.Module):
+    """Lightweight 2-layer transformer encoder for token classification.
+
+    Emits per-token logits of shape ``(batch, seq_len, output_classes)`` —
+    one BIO tag distribution per sub-word token. Intended for smoke testing
+    the token-classification training pipeline — not for production-quality
+    predictions.
+    """
+
+    def __init__(
+        self,
+        vocab_size=_VOCAB_SIZE,
+        num_labels=output_classes,
+        hidden_size=192,
+        num_layers=2,
+        num_heads=4,
+        intermediate_size=384,
+        max_position_embeddings=512,
+        dropout=0.1,
+    ):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(vocab_size, hidden_size)
+        self.position_embeddings = nn.Embedding(max_position_embeddings, hidden_size)
+        self.max_position_embeddings = max_position_embeddings
+        self.layer_norm = nn.LayerNorm(hidden_size)
+        self.dropout = nn.Dropout(dropout)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=hidden_size,
+            nhead=num_heads,
+            dim_feedforward=intermediate_size,
+            dropout=dropout,
+            activation="gelu",
+            batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        self.encoder.enable_nested_tensor = False
+        self.classifier = nn.Linear(hidden_size, num_labels)
+
+        self._init_weights()
+
+    def _init_weights(self):
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                module.weight.data.normal_(mean=0.0, std=0.02)
+                if module.bias is not None:
+                    module.bias.data.zero_()
+            elif isinstance(module, nn.Embedding):
+                module.weight.data.normal_(mean=0.0, std=0.02)
+
+    def forward(self, input_ids, attention_mask=None, **kwargs):
+        seq_len = input_ids.size(1)
+        position_ids = torch.arange(seq_len, device=input_ids.device).unsqueeze(0)
+        position_ids = position_ids.clamp(max=self.max_position_embeddings - 1)
+
+        x = self.word_embeddings(input_ids) + self.position_embeddings(position_ids)
+        x = self.layer_norm(x)
+        x = self.dropout(x)
+
+        if attention_mask is not None:
+            # TransformerEncoder expects mask where True = ignore
+            src_key_padding_mask = attention_mask == 0
+        else:
+            src_key_padding_mask = None
+
+        x = self.encoder(x, src_key_padding_mask=src_key_padding_mask)
+        # Per-token logits: (batch, seq_len, num_labels)
+        return self.classifier(x)

--- a/model_zoo/token_classification/pytorch/simple_token.py
+++ b/model_zoo/token_classification/pytorch/simple_token.py
@@ -31,7 +31,7 @@ class SimpleTokenTagger(nn.Module):
     def __init__(
         self,
         vocab_size=_VOCAB_SIZE,
-        num_labels=output_classes,
+        num_classes=output_classes,
         hidden_size=192,
         num_layers=2,
         num_heads=4,
@@ -56,7 +56,7 @@ class SimpleTokenTagger(nn.Module):
         )
         self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
         self.encoder.enable_nested_tensor = False
-        self.classifier = nn.Linear(hidden_size, num_labels)
+        self.classifier = nn.Linear(hidden_size, num_classes)
 
         self._init_weights()
 
@@ -85,5 +85,5 @@ class SimpleTokenTagger(nn.Module):
             src_key_padding_mask = None
 
         x = self.encoder(x, src_key_padding_mask=src_key_padding_mask)
-        # Per-token logits: (batch, seq_len, num_labels)
+        # Per-token logits: (batch, seq_len, num_classes)
         return self.classifier(x)

--- a/model_zoo/token_classification/pytorch/xlm_roberta_token.py
+++ b/model_zoo/token_classification/pytorch/xlm_roberta_token.py
@@ -1,0 +1,20 @@
+"""XLM-RoBERTa-base with a per-token classification head. SOTA multilingual NER/POS across 100 languages; the default for non-English token tagging."""
+from transformers import AutoModelForTokenClassification
+
+model_id = "xlm-roberta-base"
+framework = "pytorch"
+main_class = "MyModel"
+category = "token_classification"
+model_type = ""
+batch_size = 16
+sequence_length = 128
+# BIO/IOB2 tag count. Default 9 matches the CoNLL-2003 scheme:
+# O + B/I x {PER, ORG, LOC, MISC}. Set to your dataset's tag count.
+output_classes = 9
+license = "MIT"
+
+
+def MyModel(num_classes=output_classes):
+    return AutoModelForTokenClassification.from_pretrained(
+        model_id, num_labels=num_classes, ignore_mismatched_sizes=True
+    )

--- a/tests/test_model_contract.py
+++ b/tests/test_model_contract.py
@@ -50,6 +50,7 @@ KNOWN_CATEGORIES = {
     "time_series_forecasting",
     "time_to_event_prediction",
     "masked_language_modeling",
+    "token_classification",
 }
 
 


### PR DESCRIPTION
Adds the full **token_classification (NER/POS)** model set to the zoo. Consolidates the previously-stacked #94 (starter models) into this single PR against `develop`.

### Starter models
- `simple_token.py` — minimal 2-layer transformer tagger (~6.6M params), smoke-test / pipeline validation
- `bert_token.py` — `bert-base` HF token-classification factory
- `distil_token.py` — `distilbert-base` HF factory

### SOTA backbones
- `roberta_token.py`, `xlm_roberta_token.py`, `electra_token.py`, `deberta_v3_token.py`, `modernbert_token.py`

### Contract
- All emit per-token logits `(batch, seq_len, output_classes)`; `output_classes` defaults to 9 (CoNLL scheme), set to the dataset's BIO tag count.
- Constructors use `num_classes=output_classes`, matching the zoo loader contract (the earlier `num_labels` mismatch on `simple_token` is fixed here).
- `tests/test_model_contract.py` extended with `token_classification`; all green.

Supersedes #94.