### PR TITLE
ci: add concurrency cancellation + job timeouts to model-zoo CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,13 @@ on:
   push:
     branches: [master, develop]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ruff:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +25,7 @@ jobs:
       - run: ruff check --select=F401,F821,E9 model_zoo/
 
   test-pytorch:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +38,7 @@ jobs:
       - run: pytest tests/ -v
 
   test-tensorflow:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +51,7 @@ jobs:
       - run: pytest tests/ -v
 
   test-sklearn:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +64,7 @@ jobs:
       - run: pytest tests/ -v
 
   test-survival:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Mechanical CI-hygiene change to `.github/workflows/ci.yml`. No change to what any job does.

- Adds a top-level `concurrency:` group keyed on `github.ref`, with `cancel-in-progress` scoped to `pull_request` events only — so a PR re-push cancels its own superseded run instead of stacking the heavy framework test matrices. Pushes to branches are not cancelled.
- Adds `timeout-minutes` as the first key of every job:
  - `ruff` → 10
  - `test-pytorch` / `test-tensorflow` / `test-sklearn` / `test-survival` → 30 (these pip-install torch/tensorflow/etc., so they're heavier)

This caps hung installs at the configured limit instead of letting them run to the 6h GitHub default.

## Type

CI hygiene

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML OK
- Diff contains only the `concurrency:` block + per-job `timeout-minutes` additions; no job `runs-on`/`steps` lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
