### PR TITLE
fix(nlp): bake pad padding into causal/MLM/token/text tokenizers

### DIFF
--- a/model_zoo/causal_language_modeling/pytorch/bert_vocab_tokenizer.json
+++ b/model_zoo/causal_language_modeling/pytorch/bert_vocab_tokenizer.json
@@ -1,7 +1,14 @@
 {
   "version": "1.0",
   "truncation": null,
-  "padding": null,
+  "padding": {
+    "strategy": "BatchLongest",
+    "direction": "Right",
+    "pad_to_multiple_of": null,
+    "pad_id": 0,
+    "pad_type_id": 0,
+    "pad_token": "[PAD]"
+  },
   "added_tokens": [
     {
       "id": 0,

--- a/model_zoo/masked_language_modeling/pytorch/tokenizer.json
+++ b/model_zoo/masked_language_modeling/pytorch/tokenizer.json
@@ -1,7 +1,14 @@
 {
   "version": "1.0",
   "truncation": null,
-  "padding": null,
+  "padding": {
+    "strategy": "BatchLongest",
+    "direction": "Right",
+    "pad_to_multiple_of": null,
+    "pad_id": 0,
+    "pad_type_id": 0,
+    "pad_token": "[PAD]"
+  },
   "added_tokens": [
     {
       "id": 0,

--- a/model_zoo/text_classification/pytorch/simple_text_tokenizer.json
+++ b/model_zoo/text_classification/pytorch/simple_text_tokenizer.json
@@ -1,7 +1,14 @@
 {
   "version": "1.0",
   "truncation": null,
-  "padding": null,
+  "padding": {
+    "strategy": "BatchLongest",
+    "direction": "Right",
+    "pad_to_multiple_of": null,
+    "pad_id": 0,
+    "pad_type_id": 0,
+    "pad_token": "[PAD]"
+  },
   "added_tokens": [
     {
       "id": 0,

--- a/model_zoo/token_classification/pytorch/simple_token_tokenizer.json
+++ b/model_zoo/token_classification/pytorch/simple_token_tokenizer.json
@@ -1,7 +1,14 @@
 {
   "version": "1.0",
   "truncation": null,
-  "padding": null,
+  "padding": {
+    "strategy": "BatchLongest",
+    "direction": "Right",
+    "pad_to_multiple_of": null,
+    "pad_id": 0,
+    "pad_type_id": 0,
+    "pad_token": "[PAD]"
+  },
   "added_tokens": [
     {
       "id": 0,


### PR DESCRIPTION
## Why
Found while live-testing causal LM: the causal model-zoo `bert_vocab_tokenizer.json` resolved **no pad token standalone** (the #242 pattern), so the SDK correctly **rejected** any non-HF causal model shipping it — blocking the example from uploading. Auditing all model-zoo tokenizers found **4 affected** (causal, MLM, token, text); only seq2seq was fixed earlier (#102).

## Fix
Re-saved each with `backend_tokenizer.enable_padding(pad_id=0, pad_token='[PAD]')` (same one-line fix as #102) so a standalone load resolves `[PAD]`.

## Verified
- `PreTrainedTokenizerFast(tokenizer_file=...).pad_token == '[PAD]'` for all 4 (was `None`).
- The SDK's `validate_custom_tokenizer_file` now **accepts** each (was rejecting).
- model-zoo tests: **166 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to bundled tokenizer metadata; no runtime logic or auth/data paths touched.
> 
> **Overview**
> Four model-zoo **tokenizer.json** assets (causal LM BERT vocab, MLM, text classification, token classification) no longer ship with **`"padding": null`**. Each now embeds **BatchLongest / right-pad** settings with **`pad_id` 0** and **`[PAD]`**, matching the seq2seq fix from earlier work.
> 
> Standalone **`PreTrainedTokenizerFast`** loads should resolve **`pad_token == '[PAD]'`** instead of **`None`**, so SDK **`validate_custom_tokenizer_file`** can accept these examples for upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e42e738390501f06d8ca89230cc0412f067ff6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->