### PR TITLE
feat(survival): lifelines Cox PH template + document sksurv survival models (#79)

### DIFF
--- a/model_zoo/time_to_event_prediction/README.md
+++ b/model_zoo/time_to_event_prediction/README.md
@@ -19,6 +19,7 @@ For deep-learning approaches, try [`pytorch/deepsurv.py`](pytorch/deepsurv.py) â
 
 | Model | When to pick |
 |---|---|
+| [`cox_ph.py`](lifelines/cox_ph.py) | Semi-parametric Cox model; interpretable hazard ratios |
 | [`weibull_aft.py`](lifelines/weibull_aft.py) | Most common parametric baseline |
 | [`log_normal_aft.py`](lifelines/log_normal_aft.py) | When `log(time)` is approximately normal |
 | [`log_logistic_aft.py`](lifelines/log_logistic_aft.py) | Non-monotonic hazards |
@@ -28,6 +29,8 @@ For deep-learning approaches, try [`pytorch/deepsurv.py`](pytorch/deepsurv.py) â
 | Model | When to pick |
 |---|---|
 | [`cox_ph.py`](scikit_survival/cox_ph.py) | Classical semi-parametric Cox model; interpretable coefficients |
+| [`random_survival_forest.py`](scikit_survival/random_survival_forest.py) | Non-linear, robust; a bag of independent survival trees |
+| [`gradient_boosted_survival.py`](scikit_survival/gradient_boosted_survival.py) | Gradient-boosted survival; strong tabular accuracy |
 
 ### PyTorch (neural survival)
 

--- a/model_zoo/time_to_event_prediction/lifelines/cox_ph.py
+++ b/model_zoo/time_to_event_prediction/lifelines/cox_ph.py
@@ -1,0 +1,15 @@
+"""Cox Proportional Hazards model (lifelines). Semi-parametric survival baseline;
+federates by inverse-variance (precision) weighting of its coefficients."""
+from lifelines import CoxPHFitter
+
+framework = "lifelines"
+model_type = ""
+main_method = "MyModel"
+batch_size = 128
+output_classes = 1
+category = "time_to_event_prediction"
+num_feature_points = 12
+
+
+def MyModel():
+    return CoxPHFitter()


### PR DESCRIPTION
Model-zoo follow-up for survival FL (#79), pairing with averaging-service #171.

## What
- **New `model_zoo/time_to_event_prediction/lifelines/cox_ph.py`** (`CoxPHFitter`) — the flagship semi-parametric survival model, and the one federated via **inverse-variance (precision) weighting** of its coefficients in the averaging service (#171). Completes the #79 v1 lifelines set: Cox PH + Weibull/log-logistic AFT.
- **README**: document the already-shipped `scikit_survival` `random_survival_forest.py` and `gradient_boosted_survival.py` (they existed but weren't listed) and the new lifelines Cox PH.

## Why
Every survival template in the zoo now maps to a registered averaging-service merger:
- lifelines Cox PH / Weibull / log-logistic / log-normal AFT → `SurvivalParametricMerger`
- sksurv Cox PH → `SurvivalParametricMerger`; RSF → `SurvivalForestMerger`; GBS → `SurvivalBoostingMerger`

## Test
`tests/test_model_contract.py` passes for all `time_to_event_prediction` lifelines + scikit_survival templates (7 passed), including the new Cox PH file.

Base is `develop` per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a thin model-zoo template with no runtime or security-sensitive logic changes.
> 
> **Overview**
> Adds **`model_zoo/time_to_event_prediction/lifelines/cox_ph.py`**, a lifelines **`CoxPHFitter`** template aligned with the other lifelines survival stubs (same contract metadata and `MyModel()` factory). The module docstring notes federation via **inverse-variance (precision) weighting** of coefficients, pairing with the averaging-service survival mergers.
> 
> Updates **`model_zoo/time_to_event_prediction/README.md`** to recommend **`cox_ph.py`** under lifelines and to document **`random_survival_forest.py`** and **`gradient_boosted_survival.py`** under scikit_survival, which were already in the repo but missing from the model table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf97a58f7e308a124061d182d74398c12f910ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->