### PR TITLE
feat(tsc): add time_series_classification PyTorch templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ model_zoo/
   tabular_classification/         pytorch/, sklearn/, tensorflow/
   tabular_regression/             pytorch/, sklearn/, tensorflow/
   text_classification/            pytorch/
+  time_series_classification/     pytorch/
   time_series_forecasting/        pytorch/
   time_to_event_prediction/       lifelines/, pytorch/, scikit_survival/
   token_classification/           pytorch/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Every model in this repo is compatible with tracebloc's secure training environm
 | Tabular classification | PyTorch, sklearn, TensorFlow | `model_zoo/tabular_classification/` | Classify structured/tabular data |
 | Tabular regression | PyTorch, sklearn, TensorFlow | `model_zoo/tabular_regression/` | Predict continuous values from tables |
 | Time series forecasting | PyTorch | `model_zoo/time_series_forecasting/pytorch/` | Forecast future values from sequences |
+| Time series classification | PyTorch | `model_zoo/time_series_classification/pytorch/` | Assign one label to each whole sequence |
 | Time-to-event prediction | lifelines, PyTorch, scikit-survival | `model_zoo/time_to_event_prediction/` | Predict when an event will occur |
 
 ## Quick start

--- a/model_zoo/time_series_classification/README.md
+++ b/model_zoo/time_series_classification/README.md
@@ -1,0 +1,35 @@
+# Time series classification
+
+Assign one label to each whole sequence (e.g. classify a patient's vital-sign history, a machine's sensor trace, or an activity recording). One dataset item = one sequence; the label is constant within a sequence.
+
+## Start here
+
+**New to time-series classification?** Use [`pytorch/lstm.py`](pytorch/lstm.py). Solid general-purpose sequence classifier — start here before reaching for transformers.
+
+For a fast sanity-check baseline, try [`pytorch/masked_pool_mlp.py`](pytorch/masked_pool_mlp.py) — a per-timestep MLP with masked pooling. If it matches your recurrent models, temporal order is not carrying much signal.
+
+## Models
+
+| Model | When to pick |
+|---|---|
+| [`lstm.py`](pytorch/lstm.py) | Default sequence classifier; reliable baseline |
+| [`gru.py`](pytorch/gru.py) | Lighter than LSTM; faster training on short sequences |
+| [`tcn.py`](pytorch/tcn.py) | Dilated causal convs; strong on long sequences |
+| [`transformer.py`](pytorch/transformer.py) | Self-attention; needs a lot of data to justify |
+| [`masked_pool_mlp.py`](pytorch/masked_pool_mlp.py) | Order-agnostic baseline; fastest to train |
+
+## Dataset expectations
+
+- **Input**: `(B, sequence_length, num_feature_points)` float32. Sequences are scaled first, then zero **post**-padded (or tail-keep truncated) to `sequence_length`.
+- **Output**: `(B, output_classes)` raw logits — no softmax in the model.
+- **Padding**: models take a single tensor and derive the padding mask internally via `(x.abs().sum(-1) > 0)`. A timestep whose features are all exactly zero counts as padding, so scale before padding — never the other way around.
+- **Labels**: one integer class per sequence.
+
+## Writing your own
+
+Heads must respect the padding mask. In particular:
+
+- Recurrent models must read the last **valid** timestep, not `out[:, -1, :]` — that reads hidden state computed on zero padding.
+- Transformers should pass `src_key_padding_mask` and guard the all-padding edge case (a fully masked row makes attention output NaN).
+- Pooling heads must exclude padded timesteps (masked mean/max), not average over the full padded length.
+- Federated averaging constraint: no BatchNorm running stats, no EMA buffers — use LayerNorm instead.

--- a/model_zoo/time_series_classification/pytorch/gru.py
+++ b/model_zoo/time_series_classification/pytorch/gru.py
@@ -1,0 +1,47 @@
+"""GRU classifier. Lighter than LSTM; often trains faster with similar accuracy on short sequences."""
+import torch.nn as nn
+
+framework = "pytorch"
+model_type = ""
+main_class = "GRUClassifier"
+license = "Apache-2.0"
+category = "time_series_classification"
+batch_size = 512
+output_classes = 2
+num_feature_points = 9
+sequence_length = 60
+
+
+class GRUClassifier(nn.Module):
+    def __init__(self, input_size=num_feature_points, hidden_size=128, num_layers=2, dropout=0.2):
+        super(GRUClassifier, self).__init__()
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+
+        self.gru = nn.GRU(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=dropout if num_layers > 1 else 0,
+            batch_first=True
+        )
+        self.fc1 = nn.Linear(hidden_size, 64)
+        self.fc2 = nn.Linear(64, output_classes)
+        self.relu = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        # Input shape: (batch_size, sequence_length, input_size), zero post-padded
+        # Padding mask: a timestep is valid if any feature is non-zero
+        mask = (x.abs().sum(-1) > 0)
+        gru_out, _ = self.gru(x)
+        # Take the last VALID timestep per sequence — gru_out[:, -1, :] would
+        # read hidden state computed on zero padding
+        lengths = mask.sum(dim=1)
+        last_valid = (lengths - 1).clamp(min=0)  # all-padding edge case -> index 0
+        idx = last_valid.view(-1, 1, 1).expand(-1, 1, gru_out.size(-1))
+        last_output = gru_out.gather(1, idx).squeeze(1)
+        x = self.relu(self.fc1(last_output))
+        x = self.dropout(x)
+        x = self.fc2(x)
+        return x

--- a/model_zoo/time_series_classification/pytorch/lstm.py
+++ b/model_zoo/time_series_classification/pytorch/lstm.py
@@ -1,0 +1,47 @@
+"""LSTM classifier, 2-layer, hidden=128. Good general-purpose sequence classifier; start here before transformers."""
+import torch.nn as nn
+
+framework = "pytorch"
+model_type = ""
+main_class = "LSTMClassifier"
+license = "Apache-2.0"
+category = "time_series_classification"
+batch_size = 512
+output_classes = 2
+num_feature_points = 9
+sequence_length = 60
+
+
+class LSTMClassifier(nn.Module):
+    def __init__(self, input_size=num_feature_points, hidden_size=128, num_layers=2, dropout=0.2):
+        super(LSTMClassifier, self).__init__()
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+
+        self.lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=dropout if num_layers > 1 else 0,
+            batch_first=True
+        )
+        self.fc1 = nn.Linear(hidden_size, 64)
+        self.fc2 = nn.Linear(64, output_classes)
+        self.relu = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        # Input shape: (batch_size, sequence_length, input_size), zero post-padded
+        # Padding mask: a timestep is valid if any feature is non-zero
+        mask = (x.abs().sum(-1) > 0)
+        lstm_out, _ = self.lstm(x)
+        # Take the last VALID timestep per sequence — lstm_out[:, -1, :] would
+        # read hidden state computed on zero padding
+        lengths = mask.sum(dim=1)
+        last_valid = (lengths - 1).clamp(min=0)  # all-padding edge case -> index 0
+        idx = last_valid.view(-1, 1, 1).expand(-1, 1, lstm_out.size(-1))
+        last_output = lstm_out.gather(1, idx).squeeze(1)
+        x = self.relu(self.fc1(last_output))
+        x = self.dropout(x)
+        x = self.fc2(x)
+        return x

--- a/model_zoo/time_series_classification/pytorch/masked_pool_mlp.py
+++ b/model_zoo/time_series_classification/pytorch/masked_pool_mlp.py
@@ -1,0 +1,51 @@
+"""Per-timestep MLP with masked mean+max pooling. Simplest sequence classifier; strong baseline when temporal order matters little."""
+import torch
+import torch.nn as nn
+
+framework = "pytorch"
+model_type = ""
+main_class = "MaskedPoolMLP"
+license = "Apache-2.0"
+category = "time_series_classification"
+batch_size = 512
+output_classes = 2
+num_feature_points = 9
+sequence_length = 60
+
+
+class MaskedPoolMLP(nn.Module):
+    def __init__(self, input_size=num_feature_points, hidden_size=128, dropout=0.2):
+        super(MaskedPoolMLP, self).__init__()
+        self.feature_net = nn.Sequential(
+            nn.Linear(input_size, hidden_size),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+        )
+        self.fc1 = nn.Linear(hidden_size * 2, 64)  # mean-pool + max-pool concatenated
+        self.fc2 = nn.Linear(64, output_classes)
+        self.relu = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        # Input shape: (batch_size, sequence_length, input_size), zero post-padded
+        # Padding mask: a timestep is valid if any feature is non-zero
+        mask = (x.abs().sum(-1) > 0)
+        # Guard the all-padding edge case: max over zero valid timesteps is
+        # -inf, so treat the first timestep of such rows as valid
+        all_pad = ~mask.any(dim=1)
+        if all_pad.any():
+            mask = mask.clone()
+            mask[all_pad, 0] = True
+        h = self.feature_net(x)  # (batch_size, sequence_length, hidden_size)
+        # Masked mean pooling over valid timesteps
+        mask_f = mask.unsqueeze(-1).to(h.dtype)
+        mean_pool = (h * mask_f).sum(dim=1) / mask_f.sum(dim=1).clamp(min=1.0)
+        # Masked max pooling — padded timesteps excluded via -inf fill
+        max_pool = h.masked_fill(~mask.unsqueeze(-1), float("-inf")).max(dim=1).values
+        x = torch.cat([mean_pool, max_pool], dim=-1)
+        x = self.relu(self.fc1(x))
+        x = self.dropout(x)
+        x = self.fc2(x)
+        return x

--- a/model_zoo/time_series_classification/pytorch/tcn.py
+++ b/model_zoo/time_series_classification/pytorch/tcn.py
@@ -1,0 +1,67 @@
+"""Temporal Convolutional Network classifier. Dilated causal convs + masked global average pooling; strong on long sequences."""
+import torch.nn as nn
+
+framework = "pytorch"
+model_type = ""
+main_class = "TCNClassifier"
+license = "Apache-2.0"
+category = "time_series_classification"
+batch_size = 512
+output_classes = 2
+num_feature_points = 9
+sequence_length = 60
+
+
+class TemporalBlock(nn.Module):
+    def __init__(self, n_inputs, n_outputs, kernel_size, stride, dilation, padding, dropout=0.2):
+        super(TemporalBlock, self).__init__()
+        self.conv1 = nn.Conv1d(n_inputs, n_outputs, kernel_size,
+                               stride=stride, padding=padding, dilation=dilation)
+        self.chomp1 = nn.ConstantPad1d((0, -padding), 0)
+        self.relu1 = nn.ReLU()
+        self.dropout1 = nn.Dropout(dropout)
+
+        self.conv2 = nn.Conv1d(n_outputs, n_outputs, kernel_size,
+                               stride=stride, padding=padding, dilation=dilation)
+        self.chomp2 = nn.ConstantPad1d((0, -padding), 0)
+        self.relu2 = nn.ReLU()
+        self.dropout2 = nn.Dropout(dropout)
+
+        self.net = nn.Sequential(self.conv1, self.chomp1, self.relu1, self.dropout1,
+                                 self.conv2, self.chomp2, self.relu2, self.dropout2)
+        self.downsample = nn.Conv1d(n_inputs, n_outputs, 1) if n_inputs != n_outputs else None
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        out = self.net(x)
+        res = x if self.downsample is None else self.downsample(x)
+        return self.relu(out + res)
+
+
+class TCNClassifier(nn.Module):
+    def __init__(self, num_inputs=num_feature_points, num_channels=[64, 128, 64], kernel_size=3, dropout=0.2):
+        super(TCNClassifier, self).__init__()
+        layers = []
+        num_levels = len(num_channels)
+        for i in range(num_levels):
+            dilation_size = 2 ** i
+            in_channels = num_inputs if i == 0 else num_channels[i-1]
+            out_channels = num_channels[i]
+            padding = (kernel_size - 1) * dilation_size
+            layers += [TemporalBlock(in_channels, out_channels, kernel_size, stride=1, dilation=dilation_size,
+                                     padding=padding, dropout=dropout)]
+
+        self.network = nn.Sequential(*layers)
+        self.fc = nn.Linear(num_channels[-1], output_classes)
+
+    def forward(self, x):
+        # Input shape: (batch_size, sequence_length, num_features), zero post-padded
+        # Padding mask: a timestep is valid if any feature is non-zero
+        mask = (x.abs().sum(-1) > 0)
+        # Transpose to (batch_size, num_features, sequence_length) for Conv1d
+        y = self.network(x.transpose(1, 2))
+        # Masked global average pooling — causal convs preserve length, so
+        # padded positions align with the mask and are excluded from the mean
+        mask_f = mask.unsqueeze(1).to(y.dtype)
+        pooled = (y * mask_f).sum(dim=-1) / mask_f.sum(dim=-1).clamp(min=1.0)
+        return self.fc(pooled)

--- a/model_zoo/time_series_classification/pytorch/transformer.py
+++ b/model_zoo/time_series_classification/pytorch/transformer.py
@@ -1,0 +1,82 @@
+"""Transformer classifier. Self-attention with padding mask + masked mean pooling; needs a lot of data to justify."""
+import torch
+import torch.nn as nn
+import math
+
+framework = "pytorch"
+model_type = ""
+main_class = "TransformerClassifier"
+license = "Apache-2.0"
+category = "time_series_classification"
+batch_size = 512
+output_classes = 2
+num_feature_points = 9
+sequence_length = 60
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, d_model, max_len=5000):
+        super(PositionalEncoding, self).__init__()
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0).transpose(0, 1)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x):
+        return x + self.pe[:x.size(0), :]
+
+
+class TransformerClassifier(nn.Module):
+    def __init__(self, input_size=num_feature_points, d_model=128, nhead=8, num_layers=2, dim_feedforward=256, dropout=0.2):
+        super(TransformerClassifier, self).__init__()
+        self.d_model = d_model
+
+        # Project input to model dimension
+        self.input_projection = nn.Linear(input_size, d_model)
+        self.pos_encoder = PositionalEncoding(d_model, max_len=sequence_length)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout,
+            batch_first=False
+        )
+        self.transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+
+        self.fc1 = nn.Linear(d_model, 64)
+        self.fc2 = nn.Linear(64, output_classes)
+        self.relu = nn.ReLU()
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        # Input shape: (batch_size, sequence_length, input_size), zero post-padded
+        # Padding mask: a timestep is valid if any feature is non-zero
+        mask = (x.abs().sum(-1) > 0)
+        # Guard the all-padding edge case: a fully masked row makes attention
+        # output NaN, so treat the first timestep of such rows as valid
+        all_pad = ~mask.any(dim=1)
+        if all_pad.any():
+            mask = mask.clone()
+            mask[all_pad, 0] = True
+        # Project to model dimension
+        x = self.input_projection(x)
+        # Transpose for transformer: (sequence_length, batch_size, d_model)
+        x = x.transpose(0, 1)
+        # Add positional encoding
+        x = self.pos_encoder(x)
+        # Pass through transformer encoder; padded timesteps excluded from attention
+        x = self.transformer_encoder(x, src_key_padding_mask=~mask)
+        # Back to (batch_size, sequence_length, d_model)
+        x = x.transpose(0, 1)
+        # Masked mean pooling over valid timesteps
+        mask_f = mask.unsqueeze(-1).to(x.dtype)
+        x = (x * mask_f).sum(dim=1) / mask_f.sum(dim=1).clamp(min=1.0)
+        # Apply fully connected layers
+        x = self.relu(self.fc1(x))
+        x = self.dropout(x)
+        x = self.fc2(x)
+        return x

--- a/tests/test_model_contract.py
+++ b/tests/test_model_contract.py
@@ -44,6 +44,7 @@ KNOWN_CATEGORIES = {
     "tabular_classification",
     "tabular_regression",
     "time_series_forecasting",
+    "time_series_classification",
     "time_to_event_prediction",
     "masked_language_modeling",
     "causal_language_modeling",


### PR DESCRIPTION
## What

Adds the `time_series_classification` model templates (epic WS7): five padding-aware PyTorch sequence classifiers under `model_zoo/time_series_classification/pytorch/` plus a category README.

| Template | Encoder | Head |
|---|---|---|
| `lstm.py` | 2-layer LSTM | last **valid** timestep (gather by `mask.sum(1) - 1`) |
| `gru.py` | 2-layer GRU | last **valid** timestep |
| `tcn.py` | dilated causal conv blocks (copied from the TSF template) | masked global average pooling |
| `transformer.py` | TSF positional encoding + `TransformerEncoder` with `src_key_padding_mask=~mask` | masked mean pooling |
| `masked_pool_mlp.py` | per-timestep MLP (net-new) | masked mean+max pooling |

## Why

The TSC epic (tracebloc/backend#1054) needs zoo templates that honor the frozen tensor contract: input `(B, sequence_length, F)` float32, scaled first then zero **post**-padded; models derive the padding mask internally via `(x.abs().sum(-1) > 0)`; output `(B, output_classes)` logits. The TSF templates' `out[:, -1, :]` head is wrong under post-padding (it reads hidden state computed on zeros) — these templates fix that per architecture, and the transformer/MLP heads guard the all-padding row (which otherwise NaNs attention / -inf max pooling).

Metadata block per file: `framework` / `model_type` / `main_class` / `license` / `category="time_series_classification"` / `batch_size` / `output_classes` / `num_feature_points` / `sequence_length` — **no `forecast_horizon`**. Every layer dimension references the module-level constants so the backend regex rewrite (`experiment_runner.py`) resizes the model correctly. No BatchNorm and no EMA buffers (federated averaging constraint); the transformer uses LayerNorm.

## Scope

- New: `model_zoo/time_series_classification/pytorch/{lstm,gru,tcn,transformer,masked_pool_mlp}.py` + `model_zoo/time_series_classification/README.md`
- Touched: `tests/test_model_contract.py` (register the category in `KNOWN_CATEGORIES` — required for the contract test to pass), repo `README.md` + `CLAUDE.md` (one directory-listing row each)
- Not touched: TSF templates, all other categories, SDK/backend. No weight files — mirrors the TSF family (the zoo ships no weights).

## Test plan

**Verified locally** (macOS, torch 2.8.0 / py3.9 and torch 2.2.2 / py3.10 — both green):
- Per template ×5, via a check harness:
  - metadata block correct, `forecast_horizon` absent
  - `forward((B, L, F)) → (B, output_classes)`, no NaN, with mixed valid lengths (incl. full-length and length-1 rows)
  - CrossEntropy backward: gradients reach every trainable parameter
  - no `nn.BatchNorm*` modules; no running/EMA buffers
  - 2-epoch overfit on synthetic separable data reduces loss (e.g. TCN 0.57 → 0.18, transformer 0.43 → 0.14)
  - **masked-pooling invariance**: appending 10 zero-pad rows to a batch leaves logits unchanged (`atol=1e-5`) — catches the last-timestep bug
  - all-padding row produces finite logits (transformer/MLP NaN guard)
  - simulated backend regex rewrite of all four numeric constants → re-import → `forward((4, 30, 14)) → (4, 5)`
- `pytest tests/` — 176 passed, 31 skipped (framework-not-installed skips), including the 5 new files through `test_model_contract.py`
- `ruff check --select=F401,F821,E9` on the new directory — clean

**Deferred to CI:** the tensorflow/sklearn/survival matrix jobs (those frameworks aren't the target here; the new files are skipped in those jobs by design).

Part of tracebloc/backend#1062 (epic tracebloc/backend#1054).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model-zoo templates and documentation only; no changes to TSF, SDK, or backend runtime paths.
> 
> **Overview**
> Adds a new **`time_series_classification`** zoo category with five PyTorch sequence classifiers and a category README, wired into repo docs and **`KNOWN_CATEGORIES`** so contract tests accept the task.
> 
> Templates follow the frozen TSC contract: input `(B, sequence_length, num_feature_points)` with zero **post**-padding, internal mask `(x.abs().sum(-1) > 0)`, and per-sequence logits `(B, output_classes)` (no `forecast_horizon`). Metadata uses `category="time_series_classification"` and module-level sizing constants for backend regex rewrite.
> 
> **Padding-aware heads** (unlike TSF’s `out[:, -1, :]` on padded tails): LSTM/GRU gather the **last valid** timestep; TCN uses masked global average pooling; transformer uses `src_key_padding_mask` plus masked mean pooling with an all-padding guard; **`masked_pool_mlp.py`** adds masked mean+max pooling over a per-timestep MLP. Federated-friendly: no BatchNorm/EMA buffers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3583c8ccea273d9b33d035f6931027fb0ba583f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->