### PR TITLE
ci: add fr-pass-comment caller workflow (#963)

### DIFF
--- a/.github/workflows/fr-pass-comment-caller.yml
+++ b/.github/workflows/fr-pass-comment-caller.yml
@@ -1,0 +1,14 @@
+name: FR pass comment
+
+# Per-repo caller. Listens for /fr-pass comments and advances kanban items
+# from "FR on dev" → "Ready for staging" or "FR on staging" → "Ready for prod".
+# All logic lives in tracebloc/.github/.github/workflows/fr-pass-comment.yml.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  advance:
+    uses: tracebloc/.github/.github/workflows/fr-pass-comment.yml@main
+    secrets: inherit


### PR DESCRIPTION
Part of tracebloc/backend#963 (kanban caller rollout).

Adds the byte-identical `fr-pass-comment-caller.yml` so `/fr-pass` comments advance kanban items in this repo instead of silently no-opping. All logic lives in `tracebloc/.github`; this is the per-repo caller only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only wiring to a shared workflow; no app, auth, or data-path changes.
> 
> **Overview**
> Adds a **GitHub Actions caller** so new `/fr-pass` issue comments in this repo trigger kanban advancement instead of doing nothing.
> 
> The workflow runs on `issue_comment` `created` and delegates to the shared `tracebloc/.github` reusable workflow (`fr-pass-comment.yml@main`) with `secrets: inherit`, moving items from **FR on dev** → **Ready for staging** or **FR on staging** → **Ready for prod**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d10423aea781db7dfa81ab544a663b698e73aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->