### PR TITLE
ci(#1420): add the code-quality caller (gitleaks + house-rules)

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -1,0 +1,29 @@
+name: Code quality
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+# Supersede the previous run when a branch is pushed again.
+concurrency:
+  group: code-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    uses: tracebloc/.github/.github/workflows/code-quality.yml@main
+    with:
+      # `python: false` deliberately, despite 203 .py files in the tree. This repo
+      # already runs its OWN `ruff` check and requires it on `develop`, so enabling
+      # the shared one adds a second, differently-scoped ruff pass rather than
+      # coverage. Flip to true if the standardised diff-scoped run should replace
+      # the local one -- that is a decision about which ruff config wins, not a gap.
+      python: false
+      # No .sh files anywhere in the tree (measured 2026-08-04).
+      shell: false
+      # gitleaks + house-rules run by default, and they are the actual gap this
+      # caller closes: this repo had no credential scan and no house-rules check
+      # at all. See backend#1420.


### PR DESCRIPTION
Part of **backend#1420** (D1 enrolment). `model-zoo` was one of the repos with no `code-quality` caller at all, so it had **no credential scan and no house-rules check**.

## Flags chosen from what is actually in the tree, not copied

Measured on `develop`, 2026-08-04: **203 `.py`**, **0 `.sh`**, 10 `.yml`, 17 `.md`.

| input | value | why |
|---|---|---|
| `python` | **false** | This repo already runs its **own** `ruff` and requires it on `develop`. Enabling the shared one adds a second, differently-scoped ruff pass — extra CI time and two configs that can disagree, not extra coverage. |
| `shell` | **false** | No `.sh` files exist. |
| `credential-scan`, `house-rules` | default (on) | **This is the gap.** Neither ran here before. |

`python: false` is a deliberate deferral, not an oversight — flipping it is a one-line change if the standardised diff-scoped ruff should replace the local one. That is a decision about which ruff config wins.

## What this does not do

It does not make the new contexts **required**. `quality / gitleaks` and `quality / house-rules` have to be observed green on a real PR first — requiring a context before it has ever reported is what bricked `tracebloc-py-package/master` for six days (backend#1427). Enrolment is a follow-up once this has run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with read-only permissions; no application or deployment code is modified.
> 
> **Overview**
> Adds a **PR-triggered** workflow that calls the org-wide `tracebloc/.github` **code-quality** reusable workflow, with concurrency so newer pushes cancel in-flight runs.
> 
> **`python: false`** and **`shell: false`** keep the shared Python ruff and shell checks off so CI does not duplicate the repo’s existing **`ruff`** job in `ci.yml` or run shell lint where there are no `.sh` files. **Gitleaks** and **house-rules** stay enabled by default—the main new coverage this PR introduces.
> 
> This does not by itself make the new check contexts required on merge; that is left for a follow-up after green runs are observed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2849faf0b365187e28066a947c159de4865b0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->