### PR TITLE
ci(#1428): point ci.yml at main after the master rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [master, develop]
+    branches: [main, develop]
   push:
-    branches: [master, develop]
+    branches: [main, develop]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Follow-up to the `master` → `main` rename on this repo, part of **backend#1428** Change 2.

`ci.yml` filtered on `master` in both triggers:

```yaml
on:
  pull_request:
    branches: [master, develop]
  push:
    branches: [master, develop]
```

**GitHub's rename redirect does not rewrite `branches:` filters in workflow YAML.** So without this, `ruff`, `test-pytorch`, `test-tensorflow`, `test-sklearn` and `test-survival` would silently stop running on the prod branch — while remaining *required* status checks on it. That combination is worse than either failure alone: the checks would sit as "Expected — waiting for status" forever and the branch would be unmergeable, with nothing in the config explaining why.

Both occurrences now read `[main, develop]`. Zero `master` references remain in the file.

## The rest of the rename, for the record

Done and verified before this PR:

| step | result |
|---|---|
| Protection re-attached to `main` | ✅ identical to the pre-rename record — `ruff, test-pytorch, test-tensorflow, test-sklearn, test-survival, gate / gate`, 1 approval, `tracebloc-release-train` bypass, `enforce_admins: true`, conversation resolution |
| `master` gone | ✅ confirmed by `git ls-remote` **and** `git/ref/heads/master` → 404 |
| `default_branch` | `master` → **`develop`** (Change 1) |
| `promotion-branches-merge-commit-only` ruleset | **created** — this repo had none, because it was not enrolled when #1416 phase 1 ran. `main` and `staging` now allow merge commits only; `develop` untouched |

The two other workflows mentioning `master` (`advance-deploy-env.yml`, `fr-gate-caller.yml`) already list `main` alongside it, so they keep working; their now-dead `master` entries are cosmetic and left for a sweep rather than churned here.

## Why the rename happened now

`model-zoo` was the one `master` repo where this was free: not yet on the train, so no hop could be in flight (#1428 forbids renaming during one), and `repos.yml` needed no second edit — `release-train#25` was updated in place from `master` to `main`.

The other four `master` repos — `backend`, `client-runtime`, `data-ingestors`, `tracebloc-py-package` — are live on the train and need the rename sequenced between hops.
