### PR TITLE
ci: pass secrets: inherit on code-quality caller (backend#1420)

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -27,3 +27,8 @@ jobs:
       # gitleaks + house-rules run by default, and they are the actual gap this
       # caller closes: this repo had no credential scan and no house-rules check
       # at all. See backend#1420.
+    # Passed for consistency across every caller in the fleet. The reusable uses NO
+    # secrets (gitleaks runs from a version+SHA-pinned binary, not the licensed
+    # action), so this is a no-op -- it also clears Cursor Bugbot's recurring false
+    # positive. Fleet-wide decision, backend#1420.
+    secrets: inherit


### PR DESCRIPTION
Fleet-wide consistency change (backend#1420). Adds `secrets: inherit` to the code-quality caller.

**No-op for behaviour** — the shared `code-quality.yml` uses no secrets and runs gitleaks from a version+SHA-pinned binary (not the licensed `gitleaks-action`), so there is nothing to inherit. Adopted across all four code-quality callers so they match each repo's other callers and to clear Cursor Bugbot's recurring (false-positive) "omits secrets inheritance" finding.

Parent: backend#1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only metadata alignment with no new secret usage or changes to quality checks.
> 
> **Overview**
> Adds **`secrets: inherit`** to the reusable **code-quality** workflow caller in `.github/workflows/code-quality-caller.yml`, with comments noting this matches other fleet callers and addresses Cursor Bugbot’s false positive about missing secrets inheritance.
> 
> **No runtime or CI behavior change** — the shared `code-quality.yml` does not consume repository secrets (gitleaks uses a pinned binary, not the licensed action).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29563cbcae7214a97eb943369311cea8d852e2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->