### PR TITLE
docs: CLAUDE.md still declared master the default branch (backend#1428)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ user = User()
 user.uploadModel("model_zoo/image_classification/pytorch/resnet_18.py")
 ```
 
-## Default branch
+## Branches
 
-`master`. Not `main`, not `develop`.
+Work lands on `develop` (the default branch); the release train promotes
+`develop -> staging -> main`. `master` no longer exists — it was renamed to
+`main` under backend#1428 Change 2. This section previously declared `master`
+the default, which misled a reviewer into flagging correct CI triggers as
+wrong (model-zoo#120).


### PR DESCRIPTION
`master` was renamed to `main` under backend#1428 Change 2 (measured: `refs/heads/master` does not exist; default branch is `develop`; the train promotes to `main`). CLAUDE.md's "Default branch: `master`. Not `main`, not `develop`." survived the rename — and just misled Bugbot into flagging the **correct** ci.yml trigger rename as dropped coverage on the staging hop ([model-zoo#120](https://github.com/tracebloc/model-zoo/pull/120)). Stale docs cost a hop cycle; this is the root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidance; no runtime, CI, or security behavior is modified.
> 
> **Overview**
> **Updates `CLAUDE.md` branch guidance** so it matches the real release train instead of claiming `master` is the default.
> 
> The old **“Default branch: `master`. Not `main`, not `develop`.”** block is replaced with a **Branches** section: work lands on **`develop`** (default), promotion is **`develop → staging → main`**, and **`master` no longer exists** (renamed to **`main`** under backend#1428). The doc also notes that the stale `master` wording previously misled review (e.g. model-zoo#120).
> 
> No code, CI, or SDK behavior changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6af0f44f142671d6749c7555eed0c9e12366bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->