### PR TITLE
ci: Q5 unwind — no secrets:inherit on the code-quality caller + BUGBOT.md rule (backend#1526)

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,29 @@
+# Bugbot guide — tracebloc/model-zoo
+
+## Context
+
+Pre-built ML model templates that users train and benchmark on the tracebloc
+platform, organized by task type (image classification, object detection, NLP,
+tabular, …). Public repo, Apache-2.0.
+
+## Known non-issues — do not flag
+
+- A `code-quality-caller.yml` that passes **no `secrets:` line** is correct, not an omission.
+  The shared `code-quality.yml` reusable references no secrets by contract
+  (RFC-BACKEND-1405 Q5, backend#1526): secretless callees get no secrets line, and if the
+  reusable ever gains one, callers switch to explicit per-secret passing — never
+  `secrets: inherit`. Flag the *addition* of `secrets: inherit` on this caller instead.
+
+## Tone
+
+Direct. Name the file and line. Give a concrete fix, not "consider".
+
+This repo is **public**: never put a customer name, internal hostname, or internal-only ticket detail in a finding. A bare `tracebloc/backend#NNNN` reference is fine.
+
+## Working with Bugbot findings (team norm)
+
+Every Bugbot review thread gets a reply, then gets resolved:
+- **Fixed**: say what changed and in which commit.
+- **False positive**: say why, with evidence (file/line, measured behavior).
+Unresolved cursor threads HOLD release-train promotions (soft gate) — an
+unaddressed finding blocks the fleet, not just this PR.

--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -27,8 +27,3 @@ jobs:
       # gitleaks + house-rules run by default, and they are the actual gap this
       # caller closes: this repo had no credential scan and no house-rules check
       # at all. See backend#1420.
-    # Passed for consistency across every caller in the fleet. The reusable uses NO
-    # secrets (gitleaks runs from a version+SHA-pinned binary, not the licensed
-    # action), so this is a no-op -- it also clears Cursor Bugbot's recurring false
-    # positive. Fleet-wide decision, backend#1420.
-    secrets: inherit


### PR DESCRIPTION
## Summary

Fleet half of the RFC-BACKEND-1405 Q5 unwind (tracebloc/backend#1526). Q5 was answered 2026-08-04 via tracebloc/rfcs#11: the shared `code-quality.yml` reusable references **no** secrets by contract, so secretless callees carry **no** `secrets:` line at all — and if the reusable ever gains a secret, callers switch to explicit per-secret passing, never `secrets: inherit`.

- **`.github/workflows/code-quality-caller.yml`** — removed the trailing `secrets: inherit` line together with its 4-line justification comment (the backend#1420-era "consistency no-op"). Everything else in the file is byte-identical; `jobs.quality.uses` still points at `tracebloc/.github/.github/workflows/code-quality.yml@main`. The reusable uses no secrets, so behavior is unchanged.
- **`.cursor/BUGBOT.md`** — new file. Encodes the same contract as a "Known non-issues — do not flag" rule, so Bugbot stops flagging the now-absent `secrets:` line as an omission and instead flags the *addition* of `secrets: inherit` on this caller.

Part of tracebloc/backend#1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI wiring and documentation only; no application or secret-handling logic changes, and the reusable workflow was already secretless.
> 
> **Overview**
> Implements the **RFC-BACKEND-1405 Q5** fleet unwind (backend#1526): **`code-quality-caller.yml` no longer passes `secrets: inherit`**, and the old “fleet consistency no-op” comment block is removed. The job still calls the same shared `code-quality.yml` reusable with the same `with:` flags; because that workflow uses no secrets, CI behavior should be unchanged.
> 
> Adds **`.cursor/BUGBOT.md`** so reviewers treat a **missing `secrets:` line** on this caller as correct and only raise findings if someone **re-adds `secrets: inherit`**, with brief repo context and public-repo tone norms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d64b8a55e7cfe81abb8c431c9e18bce19bbc6b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->