### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,29 @@
+# Bugbot guide — tracebloc/model-zoo
+
+## Context
+
+Pre-built ML model templates that users train and benchmark on the tracebloc
+platform, organized by task type (image classification, object detection, NLP,
+tabular, …). Public repo, Apache-2.0.
+
+## Known non-issues — do not flag
+
+- A `code-quality-caller.yml` that passes **no `secrets:` line** is correct, not an omission.
+  The shared `code-quality.yml` reusable references no secrets by contract
+  (RFC-BACKEND-1405 Q5, backend#1526): secretless callees get no secrets line, and if the
+  reusable ever gains one, callers switch to explicit per-secret passing — never
+  `secrets: inherit`. Flag the *addition* of `secrets: inherit` on this caller instead.
+
+## Tone
+
+Direct. Name the file and line. Give a concrete fix, not "consider".
+
+This repo is **public**: never put a customer name, internal hostname, or internal-only ticket detail in a finding. A bare `tracebloc/backend#NNNN` reference is fine.
+
+## Working with Bugbot findings (team norm)
+
+Every Bugbot review thread gets a reply, then gets resolved:
+- **Fixed**: say what changed and in which commit.
+- **False positive**: say why, with evidence (file/line, measured behavior).
+Unresolved cursor threads HOLD release-train promotions (soft gate) — an
+unaddressed finding blocks the fleet, not just this PR.

--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -27,8 +27,3 @@ jobs:
       # gitleaks + house-rules run by default, and they are the actual gap this
       # caller closes: this repo had no credential scan and no house-rules check
       # at all. See backend#1420.
-    # Passed for consistency across every caller in the fleet. The reusable uses NO
-    # secrets (gitleaks runs from a version+SHA-pinned binary, not the licensed
-    # action), so this is a no-op -- it also clears Cursor Bugbot's recurring false
-    # positive. Fleet-wide decision, backend#1420.
-    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ user = User()
 user.uploadModel("model_zoo/image_classification/pytorch/resnet_18.py")
 ```
 
-## Default branch
+## Branches
 
-`master`. Not `main`, not `develop`.
+Work lands on `develop` (the default branch); the release train promotes
+`develop -> staging -> main`. `master` no longer exists — it was renamed to
+`main` under backend#1428 Change 2. This section previously declared `master`
+the default, which misled a reviewer into flagging correct CI triggers as
+wrong (model-zoo#120).


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to contributor/Bugbot docs and a secretless CI caller tweak; no model templates, SDK behavior, or runtime logic are touched.
> 
> **Overview**
> This promotion bundles **documentation and CI hygiene**, not model-zoo code changes.
> 
> A new **`.cursor/BUGBOT.md`** tells Cursor Bugbot how to review this public repo: secretless `code-quality-caller.yml` is correct, never flag missing `secrets:` or praise `secrets: inherit`, public-repo tone, and that unresolved Bugbot threads block release-train promotions.
> 
> **`.github/workflows/code-quality-caller.yml`** drops **`secrets: inherit`** from the reusable `code-quality` job, matching the fleet rule that callers to secretless shared workflows should omit a secrets line (and reversing a no-op that only existed to silence a false positive).
> 
> **`CLAUDE.md`** replaces the outdated “default branch is `master`” note with **`develop` → `staging` → `main`**, noting `master` was renamed to `main` so CI branch triggers are not mis-reviewed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8817ccd0b694c0b4540e848e3d8d0134453e1440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->