### PR TITLE
sec(ci): pin actions/* refs to commit SHAs (backend#1491, D10)

### DIFF
--- a/.github/workflows/add-to-kanban.yml
+++ b/.github/workflows/add-to-kanban.yml
@@ -10,7 +10,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/tracebloc/projects/2
           github-token: ${{ secrets.PROJECTS_KANBAN_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -28,8 +28,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -41,8 +41,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -54,8 +54,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -67,8 +67,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/stale-backlog.yml
+++ b/.github/workflows/stale-backlog.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 42  # 6 weeks of no activity → warning
           days-before-issue-close: 14  # +2 weeks of silence → close


### PR DESCRIPTION
Pin every `actions/*` ref in this repo's workflows to the full 40-char commit SHA it currently resolves to, with a trailing exact-version comment — same form and rules as the third-party run under backend#1490 (D10, RFC-BACKEND-1405). Behaviour-preserving: no version changes, only removal of silent tag mutation. `tracebloc/*` refs stay on `@main` by design; third-party refs were already pinned under backend#1490.

| Action | Old ref | New pin | Sites |
|---|---|---|---|
| `actions/add-to-project` | `@v1.0.2` | `244f685bbc3b7adfa8466e08b698b5577571133e` `# v1.0.2` | 1 |
| `actions/checkout` | `@v4` | `11d5960a326750d5838078e36cf38b85af677262` `# v4.4.0` | 5 |
| `actions/setup-python` | `@v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` `# v5.6.0` | 5 |
| `actions/stale` | `@v9` | `5bef64f19d7facfb25b37b414482c7164d639639` `# v9.1.0` | 1 |

**12 call sites** pinned across **3 workflow files**. Verified: actionlint clean (no new findings vs the base branch), YAML parses, no mutable `actions/*` refs remain in `.github/workflows/`.

Part of tracebloc/backend#1491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only supply-chain hardening; same action commits as before, no application or runtime logic changes.
> 
> **Overview**
> Pins **12** `actions/*` workflow references across **three** workflows from mutable version tags to **immutable 40-character commit SHAs**, each with a trailing `# vX.Y.Z` comment for readability.
> 
> **`ci.yml`** updates **10** call sites (`actions/checkout`, `actions/setup-python` in ruff and four test jobs). **`add-to-kanban.yml`** pins `actions/add-to-project`; **`stale-backlog.yml`** pins `actions/stale`. Resolved versions are unchanged—only the ref form moves from tags like `@v4` / `@v5` to fixed SHAs so tags cannot silently move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3de7a273ab96f76bbec1c9dec852c6fa3b4337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->