### PR TITLE
chore(devex): Makefile with a uniform 'make check' (backend#1606)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@
 PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
 
+# Lint tools are invoked through $(PYTHON) -m, not as bare commands on
+# PATH. `setup` pip-installs them into $(PYTHON)'s environment at a
+# pinned version; a bare `ruff` would resolve to whatever happens to be
+# first on PATH — a homebrew build, another venv — and the pin the
+# comment promises would silently not be the thing that ran. (Bugbot,
+# tracebloc/data-ingestors#461.)
+
 # ci.yml fans the same `pytest tests/` out across four framework
 # environments. Locally you install one; FRAMEWORK picks which
 # .github/requirements/<name>.txt `make setup` installs.
@@ -70,7 +77,7 @@ setup:
 # the three families here are the ones that mean "this file is broken".
 .PHONY: lint
 lint:
-	ruff check --select=F401,F821,E9 model_zoo/
+	$(PYTHON) -m ruff check --select=F401,F821,E9 model_zoo/
 
 # test: ci.yml's `pytest tests/` (one framework env at a time locally).
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,78 @@
+# Makefile for tracebloc/model-zoo — uniform entry points (backend#1606).
+#
+# Every active tracebloc repo exposes the SAME three targets, so "run
+# your tests before you push" stops being a rule you can only obey with
+# per-repo tribal knowledge:
+#
+#   make check      lint + fast tests.   Budget: under 60 s.
+#   make check-all  everything CI runs (bar the CI-only heavy suites).
+#   make setup      install what those targets need.
+#
+# This file is a THIN WRAPPER over ci.yml. It introduces no new tool,
+# no new config and no new rule. When ci.yml changes, change the
+# matching line here.
+#
+# Uses whatever python/pytest is on PATH, i.e. your active virtualenv.
+
+.DEFAULT_GOAL := help
+
+PYTHON ?= python3
+PYTEST ?= $(PYTHON) -m pytest
+
+# ci.yml fans the same `pytest tests/` out across four framework
+# environments. Locally you install one; FRAMEWORK picks which
+# .github/requirements/<name>.txt `make setup` installs.
+FRAMEWORK ?= pytorch
+
+.PHONY: help
+help:
+	@echo "tracebloc/model-zoo — make targets"
+	@echo
+	@echo "  check       ruff + the model-contract tests — run this before every push"
+	@echo "  check-all   the same, verbose — CI's extra width is four framework envs"
+	@echo "  setup       pip install the lint + FRAMEWORK requirement sets"
+	@echo
+	@echo "  individual: lint test"
+	@echo
+	@echo "  CI runs 'pytest tests/' four times, once per framework env:"
+	@echo "  pytorch, tensorflow, sklearn, survival. Locally you have one."
+	@echo "  Pick it with:  make setup FRAMEWORK=tensorflow"
+
+# ---- check: the pre-push tier ------------------------------------
+#
+# The whole suite here is two files of contract tests, so the fast tier
+# and the full tier differ only in verbosity. What CI has that a laptop
+# does not is BREADTH — the same tests against four framework installs
+# — and that is a fan-out no Makefile should try to reproduce in one
+# environment.
+.PHONY: check
+check: lint test
+	@echo "==> check: green (CI additionally runs these under 4 framework envs)"
+
+.PHONY: check-all
+check-all: lint
+	$(PYTEST) tests/ -v
+	@echo "==> check-all: green (CI additionally runs these under 4 framework envs)"
+
+# setup: dependencies only. No pre-commit / pre-push hook is installed
+# here — that is a later step of backend#1606.
+.PHONY: setup
+setup:
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install -r .github/requirements/lint.txt
+	$(PYTHON) -m pip install -r .github/requirements/$(FRAMEWORK).txt
+	@echo "==> setup: lint + $(FRAMEWORK) requirements installed; run 'make check'"
+
+# ---- individual targets ------------------------------------------
+
+# lint: ci.yml's `ruff` job, same selection and same path. Deliberately
+# narrower than the org default: this tree is example model code, and
+# the three families here are the ones that mean "this file is broken".
+.PHONY: lint
+lint:
+	ruff check --select=F401,F821,E9 model_zoo/
+
+# test: ci.yml's `pytest tests/` (one framework env at a time locally).
+.PHONY: test
+test:
+	$(PYTEST) tests/ -q


### PR DESCRIPTION
## Summary

Today every repo in the org has a different incantation for "run your
tests": `python manage.py test` here, `yarn test:coverage` there,
`make ci` in cli, `pytest tests/ -m "not slow"` somewhere else. That
makes "run your tests before you push" a rule you can only obey if you
already know the repo — which means it is not really a rule, it is
tribal knowledge with a rule's wording. The people most likely to break
it are exactly the people least likely to know the incantation.

backend#1606 fixes that by giving every active repo the same three
targets:

  make check      lint + fast tests. Budget: UNDER 60 SECONDS.
  make check-all  everything CI runs, minus the CI-only heavy suites.
  make setup      install what those targets need.

The 60-second budget is not decoration. It is the property that decides
whether anyone runs the thing: a `make check` that takes ten minutes is
a rule people learn to skip, and skipping one rule teaches skipping
others. So the split between `check` and `check-all` is drawn on
measured wall-clock time, not on taste.

The Makefile is a THIN WRAPPER. Every command in it was lifted from the
workflow that already runs it. It adds no tool, no config, and no rule,
and it changes no CI workflow — making CI call `make check` is a
separate, later wave (decision 2 on backend#1606), deliberately kept out
of this PR so that a Makefile bug cannot redden the pipeline. No
pre-commit or pre-push hook is installed here either; that is step 4.

In this repo
------------

`make check` = ci.yml's ruff job (MEASURED 0.06 s — same narrow
F401,F821,E9 selection over model_zoo/, deliberately narrower than the
org default because this tree is example model code and those three
families are the ones that mean "this file is broken") plus
`pytest tests/`.

Here `check` and `check-all` differ only in verbosity, and that is
honest rather than lazy: the suite is two files of contract tests. What
CI has that a laptop does not is BREADTH — it runs the same
`pytest tests/` four times, once per framework environment (pytorch,
tensorflow, sklearn, survival). That is a fan-out no Makefile should try
to reproduce inside one interpreter, so `make setup FRAMEWORK=<name>`
lets you pick which one you have locally, and both targets say out loud
that CI runs four.

The test suite was not timed locally — the framework requirement sets are
multi-GB and were not installed to produce a number.

## Related

Step 1 of tracebloc/backend#1606 — a `Makefile` with a uniform `check` target in every active repo. One PR per repo; this is this repo's.

## Type of change

- [x] Tech-debt / refactor (developer experience)

## Test plan

`make lint` run for real: **green in 0.06 s**, clean.

The pytest target was NOT run locally — the four framework requirement sets are
multi-GB and installing one just to produce a number was not worth it.

`make help` and the dry runs of every target parse clean.

**No CI workflow is touched in this PR.** CI parity — making the workflows call `make check` — is decision 2 on backend#1606 and lands as its own wave, deliberately after the Makefiles exist and are proven locally. No pre-commit or pre-push hook is installed here either; that is step 4.

## Checklist

- [x] Works from a clean checkout — `.PHONY` on every target, `help` is the default goal
- [x] No CI workflow modified
- [x] No pre-commit / pre-push hook installed
- [x] No secrets / credentials in the diff
- [x] Every command is copied from the workflow that already runs it — no new tool, no new config, no new rule
- [x] Portable to GNU Make 3.81 (the macOS system make)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-experience only; no production code, CI workflows, or auth/data paths change.
> 
> **Overview**
> Adds a **root `Makefile`** so local dev matches the org-wide **backend#1606** pattern: `make check`, `make check-all`, and `make setup`, with `help` as the default goal.
> 
> **`make check`** runs the same **ruff** scope as CI (`F401`, `F821`, `E9` on `model_zoo/`) via `python -m ruff`, then **`pytest tests/`** in quiet mode. **`make check-all`** is the same stack with verbose pytest. **`make setup`** installs lint deps plus one framework requirement set, selectable with **`FRAMEWORK`** (default `pytorch`; CI still fans out across four envs locally).
> 
> No workflow, hook, or new tooling is introduced—only documented wrappers over existing **ci.yml** commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a22cd09b4be3c3cca706b9c55f816596f6d5295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->