### PR TITLE
ci: arm the action-pin gate — findings fail, not just report (backend#1492)

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -24,6 +24,13 @@ jobs:
       python: false
       # No .sh files anywhere in the tree (measured 2026-08-04).
       shell: false
+      # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
+      # develop branch first, so this makes a green check stay green rather than
+      # importing a backlog. Soft-fail let #1449 add a second unpinned call site
+      # of an action while #1446 was open to pin it. Independent of soft-fail
+      # above: this repo's other jobs keep whatever posture they have.
+      action-pins: true
+      action-pins-soft-fail: false
       # gitleaks + house-rules run by default, and they are the actual gap this
       # caller closes: this repo had no credential scan and no house-rules check
       # at all. See backend#1420.


### PR DESCRIPTION
Arms `action-pins` so a mutable action ref **fails** the PR instead of merely reporting. This is backend#1492.

## Why now

The pinning work is complete — **415 mutable refs fleet-wide on 2026-08-04, zero on every develop branch today** (#1490 and #1491 closed today with that scan). This is the part that makes it *stay* done.

`action-pins` has been running here in **soft-fail** since it reached `main`: it reports a violation and lets the PR merge anyway. That is exactly the state hand-pinning already proved insufficient — while #1446 was open to pin one action, **#1449 added a second unpinned call site of the same action** in a non-overlapping hunk of the same file. Both merged cleanly, git reported no conflict because there was none, and a human reading the diff caught it. No gate did.

## Arming imports no backlog

Measured immediately before opening this, across all 15 develop branches carrying this caller:

```
TOTAL develop-branch pin violations: 0
```

So this flips a check that is already green into one that stays green. Expect `quality / action-pins` green on this PR.

## What it enforces (D10)

Third-party and `actions/*` refs pinned to a full 40-character commit SHA with a trailing exact-version comment; `tracebloc/*` refs pinned to `@main` (Q3). A floating tag can be repointed by its owner at any commit — that is the supply-chain risk this removes.

`.github` armed this first, because it publishes these workflows to every other repo and its refs are inherited fleet-wide (.github#178, backend#1603).

Parent backend#1405.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow inputs; no runtime or application code changes, and pinning was already clean on develop before enabling hard fail.
> 
> **Overview**
> **Enables hard-fail action pinning** on the shared `code-quality` reusable workflow caller: `action-pins: true` and `action-pins-soft-fail: false` in `code-quality-caller.yml`.
> 
> PRs that use mutable third-party or `actions/*` refs (instead of full SHAs with version comments, or `tracebloc/*` at `@main`) will now **fail** `quality / action-pins` instead of only reporting. Fleet develop branches were scanned at zero violations before arming, so this should not introduce a new backlog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738d254b460a0cfe5ab423e5ec0c8e11aa277045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->