### PR TITLE
docs: drop the retired PII gate from secrets guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ wrong (model-zoo#120).
 - After opening or pushing to a PR, stay on it: poll CI and Bugbot on the current head and triage every finding the same day — fix it, or reply on the thread saying why not. No silent dismissals. Unresolved threads block the merge and stall the release train's settle stage; cheap now beats expensive later.
 - A finding that recurs across PRs becomes a rule: add it to `.cursor/BUGBOT.md`, and if it is grep-expressible, to code-quality's house-rules — then stop re-arguing it in comments.
 - Style and naming rules live in tooling (black/ruff, eslint/prettier, house-rules), never in prose. If a rule matters, encode it; do not restate linter rules in CLAUDE.md files.
-- Never commit secrets, tokens, or customer data — not in code, config, tests, issues, or commit messages. gitleaks and the PII gate will catch it; don't make them.
+- Never commit secrets, tokens, or customer data — not in code, config, tests, issues, or commit messages. gitleaks will catch it; don.t make it.
 
 ### Engineer kanban
 


### PR DESCRIPTION
## Summary
The public PII gate is retired org-wide (backend#1409, tracebloc/.github#188). This CLAUDE.md line still claimed it provides secret-scanning protection, so Bugbot flags "PII gate is removed without replacement" as a **High** on every promotion hop (it held model-zoo on 2026-08-10). Drops the stale reference; gitleaks remains the secret scanner.

Doc-only, one line. Part of finishing the PII-gate removal cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to engineering standards prose with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the org-wide **Quality bar** secrets bullet in `CLAUDE.md` so it no longer names the retired public PII gate alongside `gitleaks`, aligning the doc with org-wide removal of that check and stopping stale “PII gate removed without replacement” promotion noise.
> 
> **gitleaks** remains called out as the secret scanner; wording is shortened to a single enforcement path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe85181901dfeceeb3dc7067fcb5967eaa4c234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->