### PR TITLE
release-train: staging -> main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ wrong (model-zoo#120).
 - After opening or pushing to a PR, stay on it: poll CI and Bugbot on the current head and triage every finding the same day — fix it, or reply on the thread saying why not. No silent dismissals. Unresolved threads block the merge and stall the release train's settle stage; cheap now beats expensive later.
 - A finding that recurs across PRs becomes a rule: add it to `.cursor/BUGBOT.md`, and if it is grep-expressible, to code-quality's house-rules — then stop re-arguing it in comments.
 - Style and naming rules live in tooling (black/ruff, eslint/prettier, house-rules), never in prose. If a rule matters, encode it; do not restate linter rules in CLAUDE.md files.
-- Never commit secrets, tokens, or customer data — not in code, config, tests, issues, or commit messages. gitleaks will catch it; don.t make it.
+- Never commit secrets, tokens, or customer data — not in code, config, tests, issues, or commit messages. gitleaks catches secrets in **code**. Nothing scans PR titles, descriptions or commit messages: the public PII gate that did was retired on 2026-08-06 (backend#1409), so keeping customer names out of PR prose on public repos is on you, not on a check.
 
 ### Engineer kanban
 


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to engineering standards; no runtime, security logic, or application code is modified.
> 
> **Overview**
> This promotion carries a single **org-standards** edit in `CLAUDE.md` under **Quality bar**.
> 
> The no-secrets/customer-data rule is expanded to state that **gitleaks** only scans **code**, not PR titles, descriptions, or commit messages. It notes the **public PII gate** was retired on 2026-08-06 (`backend#1409`), so keeping customer names out of PR prose on public repos is an engineer responsibility, not an automated check. A minor wording fix replaces the old “gitleaks will catch it; don.t make it” phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4fc8c0d7166fdcdb97580e17644bac63f73a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->