### PR TITLE
chore(devex): install a `make check` pre-push hook via `make setup` (backend#1606)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ install-hooks:
 	    echo "note: $$hook already exists and is not ours — leaving it untouched."; \
 	    echo "      add 'make check' to it, or remove it and re-run 'make install-hooks'."; \
 	  else \
-	    mkdir -p "$$(dirname "$$hook")"; \
+	    mkdir -p "$$(dirname "$$hook")" && \
 	    printf '%s\n' \
 	      '#!/bin/sh' \
 	      '# tracebloc pre-push hook installed by make setup (backend#1606).' \
@@ -108,9 +108,9 @@ install-hooks:
 	      '# (e.g. Go buildvcs under go test) then fails in a linked worktree with' \
 	      '# exit status 128. Clear them so make check runs as if from the shell.' \
 	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
-	      'exec make check' > "$$hook"; \
-	    chmod +x "$$hook"; \
-	    echo "==> pre-push hook installed at $$hook"; \
+	      'exec make check' > "$$hook" && \
+	    chmod +x "$$hook" && \
+	    echo "==> pre-push hook installed at $$hook" && \
 	    echo "    'make check' now runs before each push (skip once with: git push --no-verify)"; \
 	  fi; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 #
 #   make check      lint + fast tests.   Budget: under 60 s.
 #   make check-all  everything CI runs (bar the CI-only heavy suites).
-#   make setup      install what those targets need.
+#   make setup      install what those targets need, and a git pre-push hook
+#                   that runs `make check` (skip once with --no-verify).
 #
 # This file is a THIN WRAPPER over ci.yml. It introduces no new tool,
 # no new config and no new rule. When ci.yml changes, change the
@@ -37,7 +38,8 @@ help:
 	@echo
 	@echo "  check       ruff + the model-contract tests — run this before every push"
 	@echo "  check-all   the same, verbose — CI's extra width is four framework envs"
-	@echo "  setup       pip install the lint + FRAMEWORK requirement sets"
+	@echo "  setup       pip install the lint + FRAMEWORK requirement sets; installs the pre-push hook"
+	@echo "  install-hooks  (re)install the git pre-push hook that runs 'make check'"
 	@echo
 	@echo "  individual: lint test"
 	@echo
@@ -61,14 +63,52 @@ check-all: lint
 	$(PYTEST) tests/ -v
 	@echo "==> check-all: green (CI additionally runs these under 4 framework envs)"
 
-# setup: dependencies only. No pre-commit / pre-push hook is installed
-# here — that is a later step of backend#1606.
+# setup: install dependencies, then install the git pre-push hook — the
+# later step of backend#1606 — via the install-hooks target below.
 .PHONY: setup
 setup:
 	$(PYTHON) -m pip install --upgrade pip
 	$(PYTHON) -m pip install -r .github/requirements/lint.txt
 	$(PYTHON) -m pip install -r .github/requirements/$(FRAMEWORK).txt
 	@echo "==> setup: lint + $(FRAMEWORK) requirements installed; run 'make check'"
+	@$(MAKE) --no-print-directory install-hooks
+
+# install-hooks: put a pre-push hook in place that runs `make check`, so the
+# canon's "run the tests before you push" is carried by the tooling rather than
+# by memory. Factored out of `setup` so it is independently runnable and
+# testable, and so a contributor who only wants the hook need not rebuild the
+# (minutes-long) venv.
+#
+# Honest by design: the hook catches FORGETTING, not defiance — `git push
+# --no-verify` skips it and always will. And it refuses to clobber a pre-push
+# hook that is already there and not ours (e.g. one the pre-commit framework
+# manages), rather than silently stomping a contributor's setup.
+#
+# `git rev-parse --git-path hooks` (not a hard-coded `.git/hooks`) so it lands
+# in the right place inside a linked worktree or a submodule, where the git dir
+# is not `.git`.
+.PHONY: install-hooks
+install-hooks:
+	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
+	  echo "note: not a git checkout — skipping pre-push hook install"; \
+	else \
+	  hook="$$(git rev-parse --git-path hooks)/pre-push"; \
+	  if [ -e "$$hook" ] && ! grep -q 'tracebloc pre-push hook' "$$hook" 2>/dev/null; then \
+	    echo "note: $$hook already exists and is not ours — leaving it untouched."; \
+	    echo "      add 'make check' to it, or remove it and re-run 'make install-hooks'."; \
+	  else \
+	    mkdir -p "$$(dirname "$$hook")"; \
+	    printf '%s\n' \
+	      '#!/bin/sh' \
+	      '# tracebloc pre-push hook installed by make setup (backend#1606).' \
+	      '# Runs make check so a push that would be red in CI is caught locally first.' \
+	      '# It catches forgetting, not defiance: git push --no-verify skips it.' \
+	      'exec make check' > "$$hook"; \
+	    chmod +x "$$hook"; \
+	    echo "==> pre-push hook installed at $$hook"; \
+	    echo "    'make check' now runs before each push (skip once with: git push --no-verify)"; \
+	  fi; \
+	fi
 
 # ---- individual targets ------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ setup:
 # install-hooks: put a pre-push hook in place that runs `make check`, so the
 # canon's "run the tests before you push" is carried by the tooling rather than
 # by memory. Factored out of `setup` so it is independently runnable and
-# testable, and so a contributor who only wants the hook need not rebuild the
-# (minutes-long) venv.
+# testable, and so a contributor who only wants the hook need not rerun the
+# full `make setup`.
 #
 # Honest by design: the hook catches FORGETTING, not defiance — `git push
 # --no-verify` skips it and always will. And it refuses to clobber a pre-push

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,16 @@ setup:
 install-hooks:
 	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
 	  echo "note: not a git checkout — skipping pre-push hook install"; \
+	elif hp="$$(git config --get core.hooksPath 2>/dev/null || true)"; [ -n "$$hp" ] && { \
+	       hd="$$(git rev-parse --git-path hooks)"; \
+	       case "$$hd" in /*) hdd="$$hd";; *) hdd="$$PWD/$$hd";; esac; \
+	       cpar="$$(cd "$$(dirname "$$hdd")" 2>/dev/null && pwd -P || true)"; \
+	       ctop="$$(cd "$$(git rev-parse --show-toplevel)" && pwd -P)"; \
+	       [ -z "$$cpar" ] || case "$$cpar/" in "$$ctop/"*) false;; *) true;; esac; \
+	     }; then \
+	  echo "note: core.hooksPath ('$$hp') resolves outside this repo — skipping."; \
+	  echo "      Git would run hooks from that shared dir, so a repo-specific hook there"; \
+	  echo "      would fire from every repo you push; add 'make check' to it by hand instead."; \
 	else \
 	  hook="$$(git rev-parse --git-path hooks)/pre-push"; \
 	  if [ -e "$$hook" ] && ! grep -q 'tracebloc pre-push hook' "$$hook" 2>/dev/null; then \
@@ -104,9 +114,25 @@ install-hooks:
 	      '# Runs make check so a push that would be red in CI is caught locally first.' \
 	      '# It catches forgetting, not defiance: git push --no-verify skips it.' \
 	      '#' \
+	      '# Nothing to check on a delete/no-op push: a branch delete streams a' \
+	      '# local sha of all-zeros on stdin (no new commits). Skip so a red tree' \
+	      '# cannot block "git push --delete", and cleanup pushes stay free.' \
+	      'z=0000000000000000000000000000000000000000' \
+	      'had_update=0' \
+	      'while read -r _ local_sha _ _; do' \
+	      '  [ "$$local_sha" != "$$z" ] && had_update=1' \
+	      'done' \
+	      '[ "$$had_update" = 0 ] && exit 0' \
+	      '#' \
+	      '# Degrade gracefully when the toolchain is absent: GUI/IDE git clients' \
+	      '# (Tower, GitKraken, VS Code) launch hooks with a minimal PATH, so make' \
+	      '# may be missing — and several do not expose --no-verify. Skipping beats' \
+	      '# hard-blocking every push with "make: command not found".' \
+	      'command -v make >/dev/null 2>&1 || exit 0' \
+	      '#' \
 	      '# Git exports GIT_DIR/GIT_WORK_TREE/etc into hook processes; a nested git' \
-	      '# (e.g. Go buildvcs under go test) then fails in a linked worktree with' \
-	      '# exit status 128. Clear them so make check runs as if from the shell.' \
+	      '# invocation (from a test, tool, or setuptools-scm) then fails in a linked' \
+	      '# worktree with exit status 128. Clear them so make check runs as from the shell.' \
 	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
 	      'exec make check' > "$$hook" && \
 	    chmod +x "$$hook" && \

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ install-hooks:
 	      '# tracebloc pre-push hook installed by make setup (backend#1606).' \
 	      '# Runs make check so a push that would be red in CI is caught locally first.' \
 	      '# It catches forgetting, not defiance: git push --no-verify skips it.' \
+	      '#' \
+	      '# Git exports GIT_DIR/GIT_WORK_TREE/etc into hook processes; a nested git' \
+	      '# (e.g. Go buildvcs under go test) then fails in a linked worktree with' \
+	      '# exit status 128. Clear them so make check runs as if from the shell.' \
+	      'unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY' \
 	      'exec make check' > "$$hook"; \
 	    chmod +x "$$hook"; \
 	    echo "==> pre-push hook installed at $$hook"; \


### PR DESCRIPTION
## What
Step 4 of #1606, fanned out to model-zoo. `make setup` now installs a git pre-push hook that runs `make check`; factored into a standalone `install-hooks` target. Mirrors the merged reference e2e-test-agent#46.

## Design (honest by construction)
- Catches forgetting, not defiance: `git push --no-verify` always skips it.
- Won't clobber a foreign pre-push hook — it declines and says so.
- Worktree/submodule-safe via `git rev-parse --git-path hooks`.

## Test plan
Mirrors #46 (verified end-to-end there). Here: `make -n install-hooks` and `make help` parse cleanly.

Parent epic: #1680.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-experience Makefile and local git hook only; no runtime, auth, or CI behavior changes beyond optional local push checks.
> 
> **Overview**
> **`make setup`** now ends by installing a git **pre-push** hook that runs **`make check`**, so local pushes are gated the same way the repo canon describes. A standalone **`make install-hooks`** target installs or refreshes only the hook without re-running pip.
> 
> The installer is defensive: it skips non-git trees, declines when **`core.hooksPath`** points outside the repo, and **does not overwrite** an existing pre-push hook unless it is already the tracebloc-managed one. The generated hook skips no-op/delete pushes (all-zero SHAs), exits cleanly if **`make`** is missing (common with GUI git clients), clears **`GIT_*`** env vars that break nested git in worktrees, then **`exec make check`**. **`make help`** documents **`setup`** and **`install-hooks`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d96de495eb2f07b5bc19e5274094d0d5669b6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->