### PR TITLE
release-train: develop -> staging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ wrong (model-zoo#120).
 
 ### Engineer kanban
 
+- Every ticket on the board carries a `Status` — no card sits at "No Status". New tickets start in `Backlog`. **Bugs are the exception:** label them `work-type:bug` (the Bug template does it) and put them straight into `Ready` — defects don't wait for refinement.
 - Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
 - Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
 - Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to engineering workflow guidance; no runtime or security impact.
> 
> **Overview**
> Adds an **Engineer kanban** rule to org-wide standards in `CLAUDE.md`: every ticket must have a `Status` (nothing stays at "No Status"), new work starts in `Backlog`, and **bugs** skip refinement—use `work-type:bug` (from the Bug template) and move them directly to `Ready`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b42aeeb9521da182fadd3545beefb9ca822b989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->