### PR TITLE
fix(ci): arm code-quality — gitleaks was a required check that could not fail (backend#1681)

### DIFF
--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -27,10 +27,19 @@ jobs:
       # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
       # develop branch first, so this makes a green check stay green rather than
       # importing a backlog. Soft-fail let #1449 add a second unpinned call site
-      # of an action while #1446 was open to pin it. Independent of soft-fail
-      # above: this repo's other jobs keep whatever posture they have.
+      # of an action while #1446 was open to pin it. Both this and `soft-fail`
+      # below are now false, so the pin check is armed either way.
       action-pins: true
       action-pins-soft-fail: false
       # gitleaks + house-rules run by default, and they are the actual gap this
       # caller closes: this repo had no credential scan and no house-rules check
       # at all. See backend#1420.
+      # ARMED 2026-08-11 (backend#1681). Until now `soft-fail` was left at its
+      # default of TRUE, so every job here -- including the credential scan --
+      # reported findings and then exited 0. On this repo gitleaks and
+      # house-rules are REQUIRED status checks, i.e. required checks that could
+      # not fail. backend#1303 ("flip code-quality to required per repo once its
+      # backlog is clean") closed 2026-07-31, and the most recent run reports
+      # zero real findings for gitleaks, house-rules and action-pins -- so this
+      # arms a green check rather than importing a backlog.
+      soft-fail: false


### PR DESCRIPTION
## What

Sets `soft-fail: false` on this repo's `code-quality` caller.

## Why this is a real gap, not tidying

`soft-fail` defaults to **true**, so every job in this caller — `gitleaks`, `house-rules`, `action-pins` — reported its findings and then **exited 0**. On this repo `quality / gitleaks` and `quality / house-rules` are **required status checks**. They were required checks that could not fail: a genuine secret could be flagged and the PR would still be green and mergeable.

Found by the round-2 pipeline audit (backend#1681), which measured this across the fleet: 12 of 16 repos pass `soft-fail: false`; this repo was one of four that did not.

## Why it is safe to arm now

- The deferring comment pointed at **backend#1303** ("flip code-quality to required per repo once its backlog is clean") — that issue **closed 2026-07-31**.
- I measured the most recent run on this repo before flipping: **zero real findings** for `gitleaks`, `house-rules` and `action-pins`. The only annotations present are GitHub's platform-level "Node.js 20 is deprecated" notice, which is not a code-quality finding.
- `python`/`shell` are `false` here, so `ruff`/`shellcheck`/`format` are skipped and unaffected.

So this arms a check that is already green rather than importing a backlog.

## Also fixed

The comment claiming the pin check is *"Independent of soft-fail above"* — there is no `soft-fail` above it, and under the shared reusable's current OR-expression that claim was false. (The expression itself is fixed separately in tracebloc/.github#207; this PR is correct either way, since both inputs are now `false`.)

Parent epic: backend#1680.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application code; recent runs showed zero findings before arming.
> 
> **Overview**
> Sets **`soft-fail: false`** on the shared `code-quality` workflow caller so gitleaks, house-rules, and action-pins **fail the job** when they report findings instead of exiting 0.
> 
> That closes a gap where **`quality / gitleaks`** and **`quality / house-rules`** were required branch checks but could not block merges. Comments are updated to note that **`action-pins-soft-fail`** is also false and that the pin check is armed regardless of global soft-fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46cbd814c8e8e7e8d87dde496c3623b88fcfcaa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->