### PR TITLE
fix(ci): pin ruff in lint.txt — the required ruff job was unpinned (backend#1681)

### DIFF
--- a/.github/requirements/lint.txt
+++ b/.github/requirements/lint.txt
@@ -1,1 +1,4 @@
-ruff
+# Pinned to the version the org code-quality gate runs (code-quality.yml
+# `ruff-version` default). An unpinned `ruff` here meant ci.yml's REQUIRED
+# ruff job installed whatever PyPI served that day (backend#1681).
+ruff==0.15.20


### PR DESCRIPTION
## What

Pins `ruff==0.15.20` in `.github/requirements/lint.txt`.

## Why

`ci.yml`'s `ruff` job is a **required check on develop**, and it installs with `pip install -r .github/requirements/lint.txt` — which contained a bare, unpinned `ruff`. So the required lint ran whatever version PyPI served that day: any upstream ruff release could turn this repo red with no change here, and two contributors could get different verdicts on identical code.

The Makefile already claims the opposite:

> `setup` pip-installs them into `$(PYTHON)`'s environment **at a pinned version**

That was false. This makes it true.

0.15.20 is the version the org `code-quality` gate pins (`ruff-version` default), so local, CI and the shared gate now agree.

## Test plan

Ran ruff **0.15.20** against `origin/develop` with this repo's exact selection:

```
ruff check --select=F401,F821,E9 model_zoo/
All checks passed!
```

So the pin does not import a backlog.

Found by the round-2 pipeline audit, backend#1681. Parent epic: backend#1680.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin only for the lint toolchain; no application or runtime behavior changes.
> 
> **Overview**
> Pins **`ruff==0.15.20`** in `.github/requirements/lint.txt` (replacing an unpinned `ruff` entry) so the **required** `ruff` job in `ci.yml` no longer picks up whatever PyPI publishes on each run.
> 
> The pin matches the org **code-quality** gate default (`ruff-version`), aligning local installs, this repo’s CI, and the shared gate. Comments document the motivation (backend#1681).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1923cbfc53822cf4256dc1d465cefcd94e3e7a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->