### PR TITLE
release-train: develop -> staging

### DIFF
--- a/.github/requirements/lint.txt
+++ b/.github/requirements/lint.txt
@@ -1,1 +1,4 @@
-ruff
+# Pinned to the version the org code-quality gate runs (code-quality.yml
+# `ruff-version` default). An unpinned `ruff` here meant ci.yml's REQUIRED
+# ruff job installed whatever PyPI served that day (backend#1681).
+ruff==0.15.20

--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -27,10 +27,19 @@ jobs:
       # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
       # develop branch first, so this makes a green check stay green rather than
       # importing a backlog. Soft-fail let #1449 add a second unpinned call site
-      # of an action while #1446 was open to pin it. Independent of soft-fail
-      # above: this repo's other jobs keep whatever posture they have.
+      # of an action while #1446 was open to pin it. Both this and `soft-fail`
+      # below are now false, so the pin check is armed either way.
       action-pins: true
       action-pins-soft-fail: false
       # gitleaks + house-rules run by default, and they are the actual gap this
       # caller closes: this repo had no credential scan and no house-rules check
       # at all. See backend#1420.
+      # ARMED 2026-08-11 (backend#1681). Until now `soft-fail` was left at its
+      # default of TRUE, so every job here -- including the credential scan --
+      # reported findings and then exited 0. On this repo gitleaks and
+      # house-rules are REQUIRED status checks, i.e. required checks that could
+      # not fail. backend#1303 ("flip code-quality to required per repo once its
+      # backlog is clean") closed 2026-07-31, and the most recent run reports
+      # zero real findings for gitleaks, house-rules and action-pins -- so this
+      # arms a green check rather than importing a backlog.
+      soft-fail: false


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-staging` branch (a mirror of `develop`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and lint dependency pinning only; no application runtime or security logic changes.
> 
> **Overview**
> **CI reliability and enforcement** for the shared org code-quality workflow and the local required `ruff` job.
> 
> Pins **`ruff==0.15.20`** in `.github/requirements/lint.txt` (aligned with the org gate default) so `ci.yml`’s required ruff step no longer installs whatever PyPI serves on each run.
> 
> Sets **`soft-fail: false`** on `.github/workflows/code-quality-caller.yml` so gitleaks, house-rules, and related jobs can actually fail PRs that are already required checks—previously they reported findings but exited 0. Comments are updated to document that action-pins and soft-fail are both armed with no backlog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e56a550dd1ea9f6b5d04710d3dc11b18f4e6a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->