### PR TITLE
release-train: staging -> main

### DIFF
--- a/.github/requirements/lint.txt
+++ b/.github/requirements/lint.txt
@@ -1,1 +1,4 @@
-ruff
+# Pinned to the version the org code-quality gate runs (code-quality.yml
+# `ruff-version` default). An unpinned `ruff` here meant ci.yml's REQUIRED
+# ruff job installed whatever PyPI served that day (backend#1681).
+ruff==0.15.20

--- a/.github/workflows/code-quality-caller.yml
+++ b/.github/workflows/code-quality-caller.yml
@@ -27,10 +27,19 @@ jobs:
       # Armed 2026-08-06 (backend#1492). Measured zero pin violations on every
       # develop branch first, so this makes a green check stay green rather than
       # importing a backlog. Soft-fail let #1449 add a second unpinned call site
-      # of an action while #1446 was open to pin it. Independent of soft-fail
-      # above: this repo's other jobs keep whatever posture they have.
+      # of an action while #1446 was open to pin it. Both this and `soft-fail`
+      # below are now false, so the pin check is armed either way.
       action-pins: true
       action-pins-soft-fail: false
       # gitleaks + house-rules run by default, and they are the actual gap this
       # caller closes: this repo had no credential scan and no house-rules check
       # at all. See backend#1420.
+      # ARMED 2026-08-11 (backend#1681). Until now `soft-fail` was left at its
+      # default of TRUE, so every job here -- including the credential scan --
+      # reported findings and then exited 0. On this repo gitleaks and
+      # house-rules are REQUIRED status checks, i.e. required checks that could
+      # not fail. backend#1303 ("flip code-quality to required per repo once its
+      # backlog is clean") closed 2026-07-31, and the most recent run reports
+      # zero real findings for gitleaks, house-rules and action-pins -- so this
+      # arms a green check rather than importing a backlog.
+      soft-fail: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ wrong (model-zoo#120).
 
 ### Engineer kanban
 
+- Every ticket on the board carries a `Status` — no card sits at "No Status". New tickets start in `Backlog`. **Bugs are the exception:** label them `work-type:bug` (the Bug template does it) and put them straight into `Ready` — defects don't wait for refinement.
 - Picking up work: the team coordinates. `Ready` is the refined queue and the first choice when it's stocked; pulling from `Backlog` is normal when refinement hasn't caught up — say what you're taking.
 - Merging to `develop` moves the card to `On dev` automatically; there is no dev-side review.
 - Functional review happens once, on staging: when it passes, comment `/fr-pass` on the PR or drag the card to `Ready for prod`. Self-signoff is allowed.


### PR DESCRIPTION
Automated promotion by the release train (RFC-0008 D14). Head is the train-managed `release-train/to-main` branch (a mirror of `staging`), so it never collides with a human PR. Merged only when the fr-gate is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and lint pinning plus documentation only; no application or security logic changes.
> 
> **Overview**
> **CI hardening:** Pins the required local `ruff` job to `ruff==0.15.20` in `.github/requirements/lint.txt` (aligned with the org code-quality default) so `ci.yml` no longer installs an unpinned PyPI version each run.
> 
> **Code quality caller:** Sets `soft-fail: false` on the shared `code-quality.yml` workflow and updates comments so **gitleaks**, **house-rules**, and **action-pins** can actually fail required checks instead of reporting findings and exiting 0.
> 
> **Engineering standards:** Adds a **Engineer kanban** rule in `CLAUDE.md` that every ticket must have a `Status` (new work starts in `Backlog`), with bugs labeled `work-type:bug` going straight to `Ready`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7528a81f51105f4f0cd516fd22a9fa6f7e7d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->