### PR TITLE
docs(zoo): correct false "passes security check" comments on 4 hub models

### DIFF
--- a/model_zoo/image_classification/pytorch/aimv2.py
+++ b/model_zoo/image_classification/pytorch/aimv2.py
@@ -17,8 +17,15 @@ class MyModel(nn.Module):
     def __init__(self, num_classes=output_classes):
         super().__init__()
         # Native Aimv2VisionModel (config model_type="aimv2_vision_model") —
-        # no trust_remote_code, so it passes the platform security check
-        # and avoids the custom-code path's all_tied_weights_keys bug.
+        # no trust_remote_code, which avoids the custom-code path's
+        # all_tied_weights_keys bug.
+        #
+        # BLOCKED BY THE UPLOAD GATE (#1495): this model currently CANNOT be
+        # uploaded to the platform. The backend gate (bandit
+        # `_is_from_pretrained`, enforced by `CheckModelMixin.is_model_secure`)
+        # rejects ANY `*.from_pretrained(...)` call regardless of
+        # trust_remote_code, so the `AutoModel.from_pretrained` below is
+        # rejected outright — dropping trust_remote_code no longer makes it pass.
         self.backbone = AutoModel.from_pretrained(_BACKBONE_ID)
         for p in self.backbone.parameters():
             p.requires_grad = False

--- a/model_zoo/keypoint_detection/pytorch/sapiens.py
+++ b/model_zoo/keypoint_detection/pytorch/sapiens.py
@@ -1,6 +1,15 @@
 """Sapiens (Meta, ECCV 2024). Human-centric foundation model — pose, depth,
 normals, segmentation in one family.
 
+BLOCKED BY THE UPLOAD GATE (#1495)
+----------------------------------
+This model currently CANNOT be uploaded to the platform. The backend gate
+(bandit ``_is_from_pretrained``, enforced by ``CheckModelMixin.is_model_secure``)
+rejects ANY ``*.from_pretrained(...)`` call regardless of ``trust_remote_code``,
+so the ``AutoModel.from_pretrained`` call in ``MyModel`` below is rejected
+outright. The backbone-substitution note below concerns which checkpoint would
+load *if* the gate allowed hub fetches — it is not a workaround for the gate.
+
 Backbone-loading note
 ---------------------
 The official ``facebook/sapiens-pose-*`` Hub repos ship as TorchScript

--- a/model_zoo/text_classification/pytorch/gte_modernbert.py
+++ b/model_zoo/text_classification/pytorch/gte_modernbert.py
@@ -6,8 +6,13 @@ Requirements:
   token to this file.
 - No ``trust_remote_code`` needed — gte-modernbert's config declares
   ``model_type="modernbert"``, which transformers (>=4.48) loads with
-  the **native** ``ModernBertForSequenceClassification`` class. Avoiding
-  remote code is required to pass the platform's model-security check.
+  the **native** ``ModernBertForSequenceClassification`` class.
+- BLOCKED BY THE UPLOAD GATE (#1495): this model currently CANNOT be
+  uploaded to the platform. The backend gate (bandit
+  ``_is_from_pretrained``, enforced by ``CheckModelMixin.is_model_secure``)
+  rejects ANY ``*.from_pretrained(...)`` call regardless of
+  ``trust_remote_code``, so the ``from_pretrained`` call below is rejected
+  outright. Avoiding remote code no longer makes it pass the security check.
 - Resources: ~600MB download, ~2GB RAM for load. ~8GB system RAM is
   enough for the local SDK self-check. At ``sequence_length=512,
   batch_size=4`` expect ~1 minute on CPU; if it looks stuck on a

--- a/model_zoo/text_classification/pytorch/phi_3_mini.py
+++ b/model_zoo/text_classification/pytorch/phi_3_mini.py
@@ -7,8 +7,13 @@ Requirements:
   leak any secret embedded in them.
 - No ``trust_remote_code`` needed — Phi-3's config declares
   ``model_type="phi3"``, which transformers loads with the native
-  ``Phi3ForSequenceClassification`` class. Avoiding remote code is
-  required to pass the platform's model-security check.
+  ``Phi3ForSequenceClassification`` class.
+- BLOCKED BY THE UPLOAD GATE (#1495): this model currently CANNOT be
+  uploaded to the platform. The backend gate (bandit
+  ``_is_from_pretrained``, enforced by ``CheckModelMixin.is_model_secure``)
+  rejects ANY ``*.from_pretrained(...)`` call regardless of
+  ``trust_remote_code``, so the ``from_pretrained`` call below is rejected
+  outright. Avoiding remote code no longer makes it pass the security check.
 - Resources: ~8GB download (fp32), ~16GB RAM for load. ~32GB system
   RAM strongly recommended for the local SDK self-check; the CPU
   forward+backward on synthetic data takes 5-15 minutes on a laptop


### PR DESCRIPTION
## What

`aimv2`, `sapiens`, `phi_3_mini` and `gte_modernbert` fetch weights via `*.from_pretrained(...)`. Their comments claimed that dropping `trust_remote_code` lets them pass the platform's model-security check:

- `image_classification/pytorch/aimv2.py` — "no trust_remote_code, so it passes the platform security check"
- `text_classification/pytorch/phi_3_mini.py` — "Avoiding remote code is required to pass the platform's model-security check"
- `text_classification/pytorch/gte_modernbert.py` — same claim
- `keypoint_detection/pytorch/sapiens.py` — no explicit claim, but the backbone-substitution note presumes the `from_pretrained` backbone is uploadable

## Why it's false now

Since the **#1495** upload gate, the backend gate (bandit `_is_from_pretrained`, enforced by `CheckModelMixin.is_model_secure`) rejects **any** `*.from_pretrained(...)` call regardless of `trust_remote_code`:

```python
def _is_from_pretrained(qualname):
    return qualname == "from_pretrained" or qualname.endswith(".from_pretrained")
```

So all four are currently **un-uploadable**. Revision pinning would be moot because the code never runs on the platform.

## Change

Comment/docstring-only. Each file now states plainly that it is blocked by the #1495 upload gate. Model logic is untouched.

Decision (correct-comments-only, keep the files) was taken with the zoo owner rather than removing/replacing the models — appropriate if the gate is later relaxed to allow vetted non-remote-code hub loads.

This is a correctness/consistency cleanup, **separate from the backend #953 security ticket**.

## Follow-up

The gate blocks ~46 zoo files that use `from_pretrained` (including every `*_scratch.py`, which uses `AutoConfig.from_pretrained`). Those don't carry a *false* comment so they're out of scope here — tracked separately in #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, security, or upload behavior changes.
> 
> **Overview**
> **Comment-only** updates in four model zoo entries (`aimv2`, `sapiens`, `phi_3_mini`, `gte_modernbert`) so docs match current platform behavior after the **#1495** upload gate.
> 
> The PR **removes** wording that implied skipping `trust_remote_code` lets these models pass `CheckModelMixin.is_model_secure` / bandit `_is_from_pretrained`. It **adds** explicit notes that **any** `*.from_pretrained(...)` call is rejected on upload, so these hub-backed models are **not uploadable** today. For `sapiens`, it clarifies that the ViT-MAE backbone substitution note is about checkpoint choice **if** hub loads were allowed—not a gate workaround.
> 
> **No model code or loading logic changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb806cd1ab28436e62b82e6d8ad76df74c1fdf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->