### PR TITLE
ci(1606): the ruff job runs `make lint` instead of restating the selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,16 @@ jobs:
           cache: pip
           cache-dependency-path: .github/requirements/lint.txt
       - run: pip install -r .github/requirements/lint.txt
-      - run: ruff check --select=F401,F821,E9 model_zoo/
+      # `make lint` (backend#1606). The RULE SELECTION was the duplicated part:
+      # `--select=F401,F821,E9` was written out here and again in the Makefile,
+      # so widening the set in one place would have left the other checking the
+      # narrower one — and a lint job that silently checks less than the
+      # contributor's pre-push hook is the wrong way round.
+      #
+      # The pin is already single-source and stays that way: lint.txt declares
+      # ruff==0.15.20, this step installs it, and `make setup` installs the same
+      # file (backend#1681).
+      - run: make lint
 
   test-pytorch:
     timeout-minutes: 30


### PR DESCRIPTION
Part of backend#1606, under epic backend#1680. Sixth repo in the CI-parity fan-out.

## What was duplicated: the rule selection, not the pin

`--select=F401,F821,E9` was written out in `ci.yml` **and** in the Makefile's `lint` target. Widen the set in one place and the other keeps checking the narrower one.

The direction that goes unnoticed is **CI checking less than the pre-push hook** — nothing goes red to tell you, the contributor just sees local failures CI doesn't care about, and learns to skip the hook.

The **pin was already single-source** and stays that way: `.github/requirements/lint.txt` declares `ruff==0.15.20`, this job installs it, and `make setup` installs the same file (backend#1681). Nothing to fix there.

## The four framework test jobs are deliberately NOT inverted

`test-pytorch` / `test-tensorflow` / `test-sklearn` / `test-survival` each run `pytest tests/ -v` against a different requirements file, while `make test` runs `-q`.

That difference is **reporting verbosity for CI logs, not test selection**, and the framework split is expressed by *which requirements file the job installs* — not by the command. Routing them through make would de-duplicate nothing and would either make CI logs quieter or local runs noisier. Left alone on purpose.

## Job id unchanged

`ruff` is a required status check on **both develop and main**, and the job sets no `name:` — so the job id *is* the status context. Unchanged.

## Verification

`make -n lint` → `python3 -m ruff check --select=F401,F821,E9 model_zoo/`, exactly the command removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; lint behavior is intended to match the existing Makefile target exactly.
> 
> **Overview**
> The **ruff** CI job now runs **`make lint`** instead of inlining `ruff check --select=F401,F821,E9 model_zoo/`, so Ruff rule selection lives only in the Makefile.
> 
> That keeps CI aligned with local **`make lint`** / pre-push checks: updating rules in one place no longer leaves the workflow checking a narrower set with no signal. The job id **`ruff`** is unchanged for required status checks. Ruff version pinning via `.github/requirements/lint.txt` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4236e37f8aa1514074bed0135e0493586d8d1f85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->